### PR TITLE
Harden workflow permissions.

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -25,6 +25,8 @@ jobs:
   go-build:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: "read"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -38,6 +40,8 @@ jobs:
   go-vet:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: "read"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -51,6 +55,8 @@ jobs:
   verify-format:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: "read"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -64,6 +70,8 @@ jobs:
   verify-gomod:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: "read"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
Context: https://codeql.github.com/codeql-query-help/actions/actions-missing-workflow-permissions/

Signed-off-by: Brad Hoekstra <bhoekstra@google.com>
