### PR TITLE
Rename clustertoolkit to avoid package names with symbols.

### DIFF
--- a/pkg/tools/clustertoolkit/clustertoolkit.go
+++ b/pkg/tools/clustertoolkit/clustertoolkit.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cluster_toolkit
+package clustertoolkit
 
 import (
 	"context"

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/cluster"
-	cluster_toolkit "github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/cluster-toolkit"
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/clustertoolkit"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/giq"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/logging"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/monitoring"
@@ -32,7 +32,7 @@ type installer func(ctx context.Context, s *server.MCPServer, c *config.Config) 
 func Install(ctx context.Context, s *server.MCPServer, c *config.Config) error {
 	installers := []installer{
 		cluster.Install,
-		cluster_toolkit.Install,
+		clustertoolkit.Install,
 		giq.Install,
 		logging.Install,
 		monitoring.Install,


### PR DESCRIPTION
Signed-off-by: Brad Hoekstra <bhoekstra@google.com>
