### PR TITLE
Fix typo in README and add instructions for connecting Gemini CLI to GKE MCP HTTP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ You can set the transport mode using the following options:
 gke-mcp --server-mode http --server-port 8080
 ```
 
-#### Connecting the Gemini CLI to the HTTP Server
+#### Connecting Gemini CLI to the HTTP Server
 
 To connect Gemini CLI to the `gke-mcp` HTTP server, you need to configure the CLI to point to the correct endpoint. You can do this by updating your `~/.gemini/settings.json` file. For a basic setup without authentication, the file should look like this:
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To connect Gemini CLI to the `gke-mcp` HTTP server, you need to configure the CL
 ```json
 {
   "mcpServers": {
-    "gke_mcp": {
+    "gke": {
       "httpUrl": "http://127.0.0.1:8080/mcp"
     }
   }

--- a/README.md
+++ b/README.md
@@ -86,8 +86,25 @@ You can set the transport mode using the following options:
 `--server-port`: server port to use when server-mode is http or sse; defaults to 8080
 
 ```sh
-gkc-mcp --server-mode http --server-port 8080
+gke-mcp --server-mode http --server-port 8080
 ```
+
+### Connecting the Gemini CLI to the HTTP Server
+
+To connect Gemini CLI to the `gke-mcp` HTTP server, you need to configure the CLI to point to the correct endpoint. You can do this by updating your `~/.gemini/settings.json` file. For a basic setup without authentication, the file should look like this:
+
+```json
+{
+  "mcpServers": {
+    "gke_mcp": {
+      "httpUrl": "http://127.0.0.1:8080/mcp"
+    }
+  }
+}
+```
+
+This configuration tells Gemini CLI how to reach the gke-mcp server running on your local machine at port 8080.
+
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ You can set the transport mode using the following options:
 gke-mcp --server-mode http --server-port 8080
 ```
 
-### Connecting the Gemini CLI to the HTTP Server
+#### Connecting the Gemini CLI to the HTTP Server
 
 To connect Gemini CLI to the `gke-mcp` HTTP server, you need to configure the CLI to point to the correct endpoint. You can do this by updating your `~/.gemini/settings.json` file. For a basic setup without authentication, the file should look like this:
 
@@ -104,7 +104,6 @@ To connect Gemini CLI to the `gke-mcp` HTTP server, you need to configure the CL
 ```
 
 This configuration tells Gemini CLI how to reach the gke-mcp server running on your local machine at port 8080.
-
 
 ## Development
 


### PR DESCRIPTION
### Description

This pull request updates the `README.md` to include instructions on how to connect the `gemini-cli` to the `gke-mcp` server when it's running in HTTP mode.

### Changes Made

- Corrected the typo `gkc-mcp` to `gke-mcp`.
- Added a new section titled "Connecting Gemini CLI to the HTTP Server."
