### PR TITLE
feat: expose gemini.md as a resource

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -130,10 +130,6 @@ func startMCPServer(ctx context.Context, opts startOptions) {
 	)
 
 	s.AddResource(resource, func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
-		if request.Params.URI != geminiInstructionsURI {
-			return nil, fmt.Errorf("resource not found: %s", request.Params.URI)
-		}
-
 		return []mcp.ResourceContents{
 			mcp.TextResourceContents{
 				URI:      geminiInstructionsURI,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -118,14 +118,14 @@ func startMCPServer(ctx context.Context, opts startOptions) {
 		"GKE MCP Server",
 		version,
 		server.WithToolCapabilities(true),
-		server.WithResourceCapabilities(true, true),
+		server.WithResourceCapabilities(false, false),
 		server.WithInstructions(instructions),
 	)
 
 	resource := mcp.NewResource(
 		geminiInstructionsURI,
 		"GEMINI.md",
-		mcp.WithResourceDescription("Instructions for how to use the GKE MCP server with Gemini."),
+		mcp.WithResourceDescription("Instructions for how to use the GKE MCP server"),
 		mcp.WithMIMEType("text/markdown"),
 	)
 

--- a/pkg/tools/cluster/cluster.go
+++ b/pkg/tools/cluster/cluster.go
@@ -67,10 +67,7 @@ func Install(ctx context.Context, s *server.MCPServer, c *config.Config) error {
 }
 
 func (h *handlers) listClusters(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	projectID, err := request.RequireString("project_id")
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
+	projectID := request.GetString("project_id", h.c.DefaultProjectID())
 	location, _ := request.RequireString("location")
 	if location == "" {
 		location = "-"


### PR DESCRIPTION
Exposing the GEMINI.md as a MCP resource enables other mcp tools to utilize instructions written as opposed to just gemini cli

Demo:
https://github.com/user-attachments/assets/e2acb672-92eb-48b3-a9b9-2edcbfa77da7

