### PR TITLE
Add /gke:cost prompt

### DIFF
--- a/cmd/mcp_cmds.go
+++ b/cmd/mcp_cmds.go
@@ -57,13 +57,8 @@ func GkeCostHandler(ctx context.Context, request mcp.GetPromptRequest) (*mcp.Get
 		return nil, fmt.Errorf("user_question is required")
 	}
 
-	tmpl, err := template.New("gkeCost").Parse(gkeCostPromptTemplate)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse prompt template: %w", err)
-	}
-
 	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, map[string]string{"user_question": userQuestion}); err != nil {
+	if err := gkeCostTmpl.Execute(&buf, map[string]string{"user_question": userQuestion}); err != nil {
 		return nil, fmt.Errorf("failed to execute prompt template: %w", err)
 	}
 

--- a/cmd/mcp_cmds.go
+++ b/cmd/mcp_cmds.go
@@ -1,3 +1,7 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0

--- a/cmd/mcp_cmds.go
+++ b/cmd/mcp_cmds.go
@@ -1,0 +1,75 @@
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"text/template"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// GkeCostPrompt defines the /gke:cost command
+var GkeCostPrompt = mcp.NewPrompt("gke:cost",
+	mcp.WithPromptDescription("Answer natural language questions about GKE-related costs by leveraging the bundled cost context instructions within the gke-mcp server."),
+	mcp.WithArgument("user_question",
+		mcp.ArgumentDescription("The user's natural language question about GKE costs"),
+		mcp.RequiredArgument(),
+	),
+)
+
+const gkeCostPromptTemplate = `
+You are a GKE cost and optimization expert. Answer the user's question about GKE costs, optimization, or billing using the comprehensive cost context available in the GKE MCP server.
+User Question: {{.user_question}}
+Based on the GKE cost context available, provide a detailed and helpful response that includes:
+1. **Direct Answer**: Address the specific cost question or optimization request
+2. **BigQuery Integration**: Explain how to use BigQuery for cost analysis if relevant
+3. **Cost Allocation**: Mention GKE Cost Allocation requirements when applicable
+4. **Actionable Steps**: Provide concrete next steps or commands when possible
+5. **Resource References**: Point to relevant GCP documentation or console links
+Key points to remember:
+- GKE costs come from GCP Billing Detailed BigQuery Export
+- BigQuery CLI (bq) is preferred over BigQuery Studio when available
+- GKE Cost Allocation must be enabled for namespace and workload-level cost data
+- Required parameters include BigQuery table path, time frame, project ID, cluster details
+- Use the cost analysis queries from the GKE MCP documentation as templates
+Always be helpful, specific, and actionable in your response.
+`
+
+// GkeCostHandler is the handler function for the /gke:cost prompt
+func GkeCostHandler(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	userQuestion := request.Params.Arguments["user_question"]
+	if userQuestion == "" {
+		return nil, fmt.Errorf("user_question is required")
+	}
+
+	tmpl, err := template.New("gkeCost").Parse(gkeCostPromptTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse prompt template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, map[string]string{"user_question": userQuestion}); err != nil {
+		return nil, fmt.Errorf("failed to execute prompt template: %w", err)
+	}
+
+	return mcp.NewGetPromptResult(
+		"GKE Cost Analysis Prompt",
+		[]mcp.PromptMessage{
+			mcp.NewPromptMessage(
+				mcp.RoleUser, // Using RoleUser to pass the whole block as user input
+				mcp.NewTextContent(buf.String()),
+			),
+		},
+	), nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,7 @@ import (
 	"cloud.google.com/go/container/apiv1/containerpb"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/install"
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/prompts/cost"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -158,7 +159,7 @@ func startMCPServer(ctx context.Context, opts startOptions) {
 		}, nil
 	})
 
-	s.AddPrompt(GkeCostPrompt, GkeCostHandler)
+	s.AddPrompt(cost.GkeCostPrompt, cost.GkeCostHandler)
 
 	if err := tools.Install(ctx, s, c); err != nil {
 		log.Fatalf("Failed to install tools: %v\n", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -157,7 +157,7 @@ func startMCPServer(ctx context.Context, opts startOptions) {
 			},
 		}, nil
 	})
-	
+
 	s.AddPrompt(GkeCostPrompt, GkeCostHandler)
 
 	if err := tools.Install(ctx, s, c); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -157,6 +157,8 @@ func startMCPServer(ctx context.Context, opts startOptions) {
 			},
 		}, nil
 	})
+	
+	s.AddPrompt(GkeCostPrompt, GkeCostHandler)
 
 	if err := tools.Install(ctx, s, c); err != nil {
 		log.Fatalf("Failed to install tools: %v\n", err)

--- a/pkg/prompts/cost/cost.go
+++ b/pkg/prompts/cost/cost.go
@@ -53,7 +53,7 @@ var GkeCostPrompt = mcp.NewPrompt("gke:cost",
 )
 
 // GkeCostHandler is the handler function for the /gke:cost prompt
-func GkeCostHandler(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+func GkeCostHandler(_ context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
 	userQuestion := request.Params.Arguments["user_question"]
 	if userQuestion == "" {
 		return nil, fmt.Errorf("user_question is required")

--- a/pkg/prompts/cost/cost.go
+++ b/pkg/prompts/cost/cost.go
@@ -23,15 +23,6 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
-// GkeCostPrompt defines the /gke:cost command
-var GkeCostPrompt = mcp.NewPrompt("gke:cost",
-	mcp.WithPromptDescription("Answer natural language questions about GKE-related costs by leveraging the bundled cost context instructions within the gke-mcp server."),
-	mcp.WithArgument("user_question",
-		mcp.ArgumentDescription("The user's natural language question about GKE costs"),
-		mcp.RequiredArgument(),
-	),
-)
-
 const gkeCostPromptTemplate = `
 You are a GKE cost and optimization expert. Answer the user's question about GKE costs, optimization, or billing using the comprehensive cost context available in the GKE MCP server.
 User Question: {{.user_question}}
@@ -51,6 +42,15 @@ Always be helpful, specific, and actionable in your response.
 `
 
 var gkeCostTmpl = template.Must(template.New("gke-cost").Parse(gkeCostPromptTemplate))
+
+// GkeCostPrompt defines the /gke:cost command
+var GkeCostPrompt = mcp.NewPrompt("gke:cost",
+	mcp.WithPromptDescription("Answer natural language questions about GKE-related costs by leveraging the bundled cost context instructions within the gke-mcp server."),
+	mcp.WithArgument("user_question",
+		mcp.ArgumentDescription("The user's natural language question about GKE costs"),
+		mcp.RequiredArgument(),
+	),
+)
 
 // GkeCostHandler is the handler function for the /gke:cost prompt
 func GkeCostHandler(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {

--- a/pkg/prompts/cost/cost.go
+++ b/pkg/prompts/cost/cost.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmd
+package cost
 
 import (
 	"bytes"
@@ -49,6 +49,8 @@ Key points to remember:
 - Use the cost analysis queries from the GKE MCP documentation as templates
 Always be helpful, specific, and actionable in your response.
 `
+
+var gkeCostTmpl = template.Must(template.New("gke-cost").Parse(gkeCostPromptTemplate))
 
 // GkeCostHandler is the handler function for the /gke:cost prompt
 func GkeCostHandler(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {

--- a/pkg/prompts/cost/cost.go
+++ b/pkg/prompts/cost/cost.go
@@ -55,8 +55,8 @@ var GkeCostPrompt = mcp.NewPrompt("gke:cost",
 // GkeCostHandler is the handler function for the /gke:cost prompt
 func GkeCostHandler(_ context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
 	userQuestion := request.Params.Arguments["user_question"]
-	if userQuestion == "" {
-		return nil, fmt.Errorf("user_question is required")
+	if strings.TrimSpace(userQuestion) == "" {
+		return nil, fmt.Errorf("argument 'user_question' cannot be empty")
 	}
 
 	var buf bytes.Buffer

--- a/pkg/prompts/cost/cost.go
+++ b/pkg/prompts/cost/cost.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"text/template"
 
 	"github.com/mark3labs/mcp-go/mcp"


### PR DESCRIPTION
Introduces a new server-side prompt command, /gke:cost, to the gke-mcp server. 

This pr implements the same functionality as pr #82, but by leveraging mcp prompt instead of gemini-cli slash commands. From the users' experience they are the same.