### PR TITLE
fix: Remove 'v' prefix from Gemini extension version.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Update version in file
         run: |
-          sed "s/\"version\": .*/\"version\": \"${{ steps.get_version.outputs.VERSION }}\"/g" gemini-extension.json > gemini-extension.json.out
+          sed "s/\"version\": .*/\"version\": \"${{ steps.get_version.outputs.VERSION }}\"/g;s/: \"v/: \"/g" gemini-extension.json > gemini-extension.json.out
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -7,5 +7,5 @@
     }
   },
   "name": "gke-mcp",
-  "version": "v0.3.0"
+  "version": "0.4.0"
 }


### PR DESCRIPTION
Currently Gemini CLI shows the extension version as "vv0.4.0", this fixes that.

Signed-off-by: Brad Hoekstra <bhoekstra@google.com>
