### PR TITLE
Add OWNERS file, so Prow can respect /lgtm && /approval labels

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- bradhoekstra
+- juli4n
+- krzyzacy
+- adamparco
+- GinnyJI
+


### PR DESCRIPTION
We can enable blunderbuss, auto-merge, and auto-trigger for CI later

https://github.com/GoogleCloudPlatform/gke-mcp/issues/125