### PR TITLE
Add get_metric_schema for GKE resource schemas

### DIFF
--- a/pkg/tools/monitoring/monitoring.go
+++ b/pkg/tools/monitoring/monitoring.go
@@ -49,6 +49,8 @@ func Install(_ context.Context, s *mcp.Server, c *config.Config) error {
 		},
 	}, h.listMRDescriptor)
 
+	installGetMetricSchemas(s)
+
 	return nil
 }
 

--- a/pkg/tools/monitoring/sample_query_validation_test.go
+++ b/pkg/tools/monitoring/sample_query_validation_test.go
@@ -1,0 +1,140 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+type metricInfo struct {
+	Kind      string
+	ValueType string
+}
+
+var metricCatalog = map[string]metricInfo{
+	"autoscaler_container_cpu_per_replica_recommended_request_cores":  {Kind: "GAUGE", ValueType: "DOUBLE"},
+	"autoscaler_container_memory_per_replica_recommended_request_bytes": {Kind: "GAUGE", ValueType: "INT64"},
+	"autoscaler_latencies_per_hpa_recommendation_scale_latency_seconds": {Kind: "GAUGE", ValueType: "DOUBLE"},
+	"container_cpu_core_usage_time":                                    {Kind: "CUMULATIVE", ValueType: "DOUBLE"},
+	"container_cpu_request_utilization":                                {Kind: "GAUGE", ValueType: "DOUBLE"},
+	"container_ephemeral_storage_used_bytes":                           {Kind: "GAUGE", ValueType: "INT64"},
+	"container_memory_limit_utilization":                               {Kind: "GAUGE", ValueType: "DOUBLE"},
+	"container_memory_used_bytes":                                      {Kind: "GAUGE", ValueType: "INT64"},
+	"container_restart_count":                                          {Kind: "CUMULATIVE", ValueType: "INT64"},
+	"jobset_proxy_runtime_goodput":                                     {Kind: "GAUGE", ValueType: "DOUBLE"},
+	"jobset_scheduling_goodput":                                        {Kind: "GAUGE", ValueType: "DOUBLE"},
+	"jobset_times_between_interruptions":                               {Kind: "GAUGE", ValueType: "DISTRIBUTION"},
+	"jobset_times_to_recover":                                          {Kind: "GAUGE", ValueType: "DISTRIBUTION"},
+	"jobset_uptime":                                                    {Kind: "GAUGE", ValueType: "DOUBLE"},
+	"node_cpu_allocatable_utilization":                                 {Kind: "GAUGE", ValueType: "DOUBLE"},
+	"node_cpu_core_usage_time":                                         {Kind: "CUMULATIVE", ValueType: "DOUBLE"},
+	"node_ephemeral_storage_used_bytes":                                {Kind: "GAUGE", ValueType: "INT64"},
+	"node_interruption_count":                                          {Kind: "GAUGE", ValueType: "INT64"},
+	"node_memory_used_bytes":                                           {Kind: "GAUGE", ValueType: "INT64"},
+	"node_network_received_bytes_count":                                {Kind: "CUMULATIVE", ValueType: "INT64"},
+	"node_pool_accelerator_times_to_recover":                           {Kind: "GAUGE", ValueType: "DISTRIBUTION"},
+	"node_pool_interruption_count":                                     {Kind: "GAUGE", ValueType: "INT64"},
+	"node_pool_multi_host_available":                                   {Kind: "GAUGE", ValueType: "BOOL"},
+	"node_pool_status":                                                 {Kind: "GAUGE", ValueType: "BOOL"},
+	"pod_ephemeral_storage_used_bytes":                                 {Kind: "GAUGE", ValueType: "INT64"},
+	"pod_latencies_pod_first_ready":                                    {Kind: "GAUGE", ValueType: "DOUBLE"},
+	"pod_network_policy_event_count":                                   {Kind: "DELTA", ValueType: "INT64"},
+	"pod_network_received_bytes_count":                                 {Kind: "CUMULATIVE", ValueType: "INT64"},
+	"pod_network_sent_bytes_count":                                     {Kind: "CUMULATIVE", ValueType: "INT64"},
+	"pod_volume_utilization":                                           {Kind: "GAUGE", ValueType: "DOUBLE"},
+}
+
+var (
+	promqlBlockRe  = regexp.MustCompile("(?s)```promql\\s*(.*?)\\s*```")
+	metricRe       = regexp.MustCompile(`kubernetes_io:([a-zA-Z0-9_]+)`)
+	rateCallRe     = regexp.MustCompile(`(?s)(?:rate|increase)\s*\(\s*[^)]*?kubernetes_io:([a-zA-Z0-9_]+)`)
+	bucketMetricRe = regexp.MustCompile(`kubernetes_io:([a-zA-Z0-9_]+)_bucket`)
+)
+
+func TestSampleQueriesMetricSemantics(t *testing.T) {
+	entries, err := os.ReadDir("schemas")
+	if err != nil {
+		t.Fatalf("read schemas directory: %v", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+
+		path := filepath.Join("schemas", entry.Name())
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read schema %s: %v", path, err)
+		}
+
+		blocks := promqlBlockRe.FindAllStringSubmatch(string(content), -1)
+		for _, block := range blocks {
+			query := block[1]
+			validateQueryMetrics(t, path, query)
+		}
+	}
+}
+
+func validateQueryMetrics(t *testing.T, path, query string) {
+	hasKubernetesMetric := false
+	for _, match := range metricRe.FindAllStringSubmatch(query, -1) {
+		metric := normalizeMetric(match[1])
+		hasKubernetesMetric = true
+		if _, ok := metricCatalog[metric]; !ok {
+			t.Errorf("%s: unknown metric %q in sample query", path, metric)
+		}
+	}
+
+	for _, match := range rateCallRe.FindAllStringSubmatch(query, -1) {
+		metric := normalizeMetric(match[1])
+		info, ok := metricCatalog[metric]
+		if !ok {
+			continue
+		}
+		if info.Kind != "CUMULATIVE" && info.Kind != "DELTA" {
+			t.Errorf("%s: rate/increase used with %q (kind=%s)", path, metric, info.Kind)
+		}
+	}
+
+	if strings.Contains(query, "histogram_quantile") && hasKubernetesMetric {
+		buckets := bucketMetricRe.FindAllStringSubmatch(query, -1)
+		if len(buckets) == 0 {
+			t.Errorf("%s: histogram_quantile used without _bucket metric", path)
+			return
+		}
+		for _, match := range buckets {
+			metric := normalizeMetric(match[1])
+			info, ok := metricCatalog[metric]
+			if !ok {
+				continue
+			}
+			if info.ValueType != "DISTRIBUTION" {
+				t.Errorf("%s: histogram_quantile used with %q (type=%s)", path, metric, info.ValueType)
+			}
+		}
+	}
+}
+
+func normalizeMetric(name string) string {
+	if strings.HasSuffix(name, "_bucket") {
+		return strings.TrimSuffix(name, "_bucket")
+	}
+	return name
+}

--- a/pkg/tools/monitoring/schema.go
+++ b/pkg/tools/monitoring/schema.go
@@ -1,0 +1,72 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"path/filepath"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+//go:embed schemas/*.md
+var metricSchemas embed.FS
+
+type GetMetricSchemaRequest struct {
+	ResourceType string `json:"resource_type" jsonschema:"The monitored resource type to get schema for. Supported values are: ['k8s_cluster', 'k8s_container', 'k8s_control_plane_component', 'k8s_entity', 'k8s_node', 'k8s_node_pool', 'k8s_pod', 'k8s_scale', 'k8s_service']."`
+}
+
+var supportedResourceTypes = map[string]bool{
+	"k8s_cluster":                 true,
+	"k8s_container":               true,
+	"k8s_control_plane_component": true,
+	"k8s_entity":                  true,
+	"k8s_node":                    true,
+	"k8s_node_pool":               true,
+	"k8s_pod":                     true,
+	"k8s_scale":                   true,
+	"k8s_service":                 true,
+}
+
+func installGetMetricSchemas(s *mcp.Server) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "get_metric_schema",
+		Description: "Get the schema for a specific GKE monitored resource type used in metric queries.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+	}, getMetricSchema)
+}
+
+func getMetricSchema(_ context.Context, _ *mcp.CallToolRequest, req *GetMetricSchemaRequest) (*mcp.CallToolResult, any, error) {
+	if !supportedResourceTypes[req.ResourceType] {
+		return nil, nil, fmt.Errorf("unsupported resource_type: %s", req.ResourceType)
+	}
+
+	fileName := fmt.Sprintf("%s.md", req.ResourceType)
+	filePath := filepath.Join("schemas", fileName)
+	content, err := metricSchemas.ReadFile(filePath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not find schema for resource_type %s: %w", req.ResourceType, err)
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(content)},
+		},
+	}, nil, nil
+}

--- a/pkg/tools/monitoring/schema_test.go
+++ b/pkg/tools/monitoring/schema_test.go
@@ -1,0 +1,54 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestGetMetricSchema(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     GetMetricSchemaRequest
+		wantErr bool
+	}{
+		{
+			name: "valid resource type",
+			req: GetMetricSchemaRequest{
+				ResourceType: "k8s_cluster",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid resource type",
+			req: GetMetricSchemaRequest{
+				ResourceType: "invalid_resource_type",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := getMetricSchema(context.Background(), &mcp.CallToolRequest{}, &tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getMetricSchema() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/tools/monitoring/schemas/k8s_cluster.md
+++ b/pkg/tools/monitoring/schemas/k8s_cluster.md
@@ -1,0 +1,86 @@
+# Kubernetes Cluster Resource Schema
+
+The `k8s_cluster` monitored resource represents a Kubernetes cluster in GKE.
+
+See [Monitored resource types](https://cloud.google.com/monitoring/api/resources) for the full list of GKE resource schemas.
+
+## Schema
+
+- Resource type: `k8s_cluster`
+- Display name: Kubernetes Cluster
+- Description: A Kubernetes cluster. It contains Kubernetes audit logs from the cluster.
+
+## Labels
+
+- `project_id`: The GCP project ID associated with the cluster.
+- `location`: The cluster location (region or zone).
+- `cluster_name`: The cluster name.
+
+## Sample queries
+
+Most GKE system metrics are emitted at node, pod, or container scope. The queries
+below roll those metrics up to cluster-level views using the cluster labels.
+
+### Cluster CPU allocatable utilization (node rollup)
+
+```promql
+topk(
+  10,
+  avg by (cluster_name) (
+    kubernetes_io:node_cpu_allocatable_utilization{monitored_resource="k8s_node"}
+  )
+)
+```
+
+### Cluster memory usage (node rollup)
+
+```promql
+topk(
+  10,
+  sum by (cluster_name) (
+    kubernetes_io:node_memory_used_bytes{
+      monitored_resource="k8s_node",
+      memory_type="non-evictable"
+    }
+  )
+)
+```
+
+### Cluster pod network throughput (pod rollup)
+
+```promql
+topk(
+  10,
+  sum by (cluster_name) (
+    rate(
+      kubernetes_io:pod_network_received_bytes_count{
+        monitored_resource="k8s_pod",
+        interface="eth0"
+      }[1m]
+    )
+  )
+)
+```
+
+### Cluster container restarts in the last 10 minutes
+
+```promql
+sort_desc(
+  sum by (cluster_name) (
+    increase(
+      kubernetes_io:container_restart_count{monitored_resource="k8s_container"}[10m]
+    )
+  )
+)
+```
+
+### Cluster ephemeral storage usage (node rollup)
+
+```promql
+topk(
+  10,
+  sum by (cluster_name) (
+    kubernetes_io:node_ephemeral_storage_used_bytes{monitored_resource="k8s_node"}
+  )
+)
+```

--- a/pkg/tools/monitoring/schemas/k8s_container.md
+++ b/pkg/tools/monitoring/schemas/k8s_container.md
@@ -1,0 +1,102 @@
+# Kubernetes Container Resource Schema
+
+The `k8s_container` monitored resource represents a container running in a Kubernetes pod.
+
+See [Monitored resource types](https://cloud.google.com/monitoring/api/resources) for the full list of GKE resource schemas.
+
+## Schema
+
+- Resource type: `k8s_container`
+- Display name: Kubernetes Container
+- Description: A Kubernetes container instance.
+
+## Labels
+
+- `project_id`: The GCP project ID associated with the cluster.
+- `location`: The cluster location (region or zone).
+- `cluster_name`: The cluster name.
+- `namespace_name`: The namespace the pod is running in.
+- `pod_name`: The pod name.
+- `container_name`: The container name.
+
+## Sample queries
+
+### Top containers by CPU cores used
+
+```promql
+topk(
+  10,
+  avg by (namespace_name, pod_name, container_name) (
+    rate(
+      kubernetes_io:container_cpu_core_usage_time{
+        monitored_resource="k8s_container",
+        cluster_name="<cluster_name>"
+      }[1m]
+    )
+  )
+)
+```
+
+### Containers with high CPU request utilization
+
+```promql
+avg by (namespace_name, pod_name, container_name) (
+  kubernetes_io:container_cpu_request_utilization{
+    monitored_resource="k8s_container",
+    cluster_name="<cluster_name>"
+  }
+) > 0.8
+```
+
+### Top containers by non-evictable memory usage
+
+```promql
+topk(
+  10,
+  avg by (namespace_name, pod_name, container_name) (
+    kubernetes_io:container_memory_used_bytes{
+      monitored_resource="k8s_container",
+      cluster_name="<cluster_name>",
+      memory_type="non-evictable"
+    }
+  )
+)
+```
+
+### Containers with high memory limit utilization
+
+```promql
+avg by (namespace_name, pod_name, container_name) (
+  kubernetes_io:container_memory_limit_utilization{
+    monitored_resource="k8s_container",
+    cluster_name="<cluster_name>"
+  }
+) > 0.8
+```
+
+### Containers restarting in the last 10 minutes
+
+```promql
+sum by (namespace_name, pod_name, container_name) (
+  increase(
+    kubernetes_io:container_restart_count{
+      monitored_resource="k8s_container",
+      cluster_name="<cluster_name>"
+    }[10m]
+  )
+) > 0
+```
+
+### Top containers by ephemeral storage usage
+
+```promql
+topk(
+  10,
+  avg by (namespace_name, pod_name, container_name) (
+    kubernetes_io:container_ephemeral_storage_used_bytes{
+      monitored_resource="k8s_container",
+      cluster_name="<cluster_name>"
+    }
+  )
+)
+```

--- a/pkg/tools/monitoring/schemas/k8s_control_plane_component.md
+++ b/pkg/tools/monitoring/schemas/k8s_control_plane_component.md
@@ -1,0 +1,79 @@
+# Kubernetes Control Plane Component Resource Schema
+
+The `k8s_control_plane_component` monitored resource represents a GKE control plane component.
+
+See [Monitored resource types](https://cloud.google.com/monitoring/api/resources) for the full list of GKE resource schemas.
+
+## Schema
+
+- Resource type: `k8s_control_plane_component`
+- Display name: Kubernetes Control Plane Component
+- Description: A Kubernetes Control Plane component.
+
+## Labels
+
+- `project_id`: The GCP project ID associated with the cluster.
+- `location`: The cluster location where the component runs.
+- `cluster_name`: The cluster name.
+- `component_name`: The control plane component name.
+- `component_location`: The location where the component runs.
+
+## Sample queries
+
+Control plane metrics vary by configuration. Replace the placeholder metric
+names below with the PromQL metric names available in your environment (for
+example, API server request latency, request count, or error count metrics).
+
+### API server request latency p95
+
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le, cluster_name) (
+    rate(
+      <request_latency_metric>_bucket{
+        monitored_resource="k8s_control_plane_component",
+        component_name="kube-apiserver"
+      }[5m]
+    )
+  )
+)
+```
+
+### Control plane request rate by component
+
+```promql
+topk(
+  5,
+  sum by (component_name) (
+    rate(
+      <request_count_metric>{
+        monitored_resource="k8s_control_plane_component"
+      }[1m]
+    )
+  )
+)
+```
+
+### Control plane error rate by component
+
+```promql
+topk(
+  5,
+  sum by (component_name) (
+    rate(
+      <error_count_metric>{
+        monitored_resource="k8s_control_plane_component"
+      }[1m]
+    )
+  )
+)
+```
+
+### Component availability by location
+
+```promql
+min by (component_location, component_name) (
+  <availability_metric>{monitored_resource="k8s_control_plane_component"}
+)
+```

--- a/pkg/tools/monitoring/schemas/k8s_entity.md
+++ b/pkg/tools/monitoring/schemas/k8s_entity.md
@@ -1,0 +1,96 @@
+# Kubernetes Entity Resource Schema
+
+The `k8s_entity` monitored resource represents a Kubernetes entity such as a workload or namespace-scoped object.
+
+See [Monitored resource types](https://cloud.google.com/monitoring/api/resources) for the full list of GKE resource schemas.
+
+## Schema
+
+- Resource type: `k8s_entity`
+- Display name: Kubernetes Entity
+- Description: A Kubernetes entity.
+
+## Labels
+
+- `project_id`: The GCP project ID associated with the cluster.
+- `location`: The cluster location that contains the entity.
+- `cluster_name`: The cluster name.
+- `entity_type`: The entity type.
+- `entity_namespace`: The entity namespace.
+- `entity_name`: The entity name.
+- `entity_uid`: The entity UID.
+
+## Sample queries
+
+### JobSet scheduling goodput (lowest)
+
+```promql
+bottomk(
+  10,
+  avg by (entity_namespace, entity_name) (
+    kubernetes_io:jobset_scheduling_goodput{
+      monitored_resource="k8s_entity",
+      cluster_name="<cluster_name>"
+    }
+  )
+)
+```
+
+### JobSet proxy runtime goodput (lowest)
+
+```promql
+bottomk(
+  10,
+  avg by (entity_namespace, entity_name) (
+    kubernetes_io:jobset_proxy_runtime_goodput{
+      monitored_resource="k8s_entity",
+      cluster_name="<cluster_name>"
+    }
+  )
+)
+```
+
+### Time between interruptions (p50)
+
+```promql
+histogram_quantile(
+  0.50,
+  sum by (le, entity_namespace, entity_name) (
+    kubernetes_io:jobset_times_between_interruptions_bucket{
+      monitored_resource="k8s_entity",
+      cluster_name="<cluster_name>"
+    }
+  )
+)
+```
+
+### Time to recover from interruptions (p95)
+
+```promql
+topk(
+  10,
+  histogram_quantile(
+    0.95,
+    sum by (le, entity_namespace, entity_name) (
+      kubernetes_io:jobset_times_to_recover_bucket{
+        monitored_resource="k8s_entity",
+        cluster_name="<cluster_name>"
+      }
+    )
+  )
+)
+```
+
+### JobSet uptime by entity
+
+```promql
+topk(
+  10,
+  max by (entity_namespace, entity_name) (
+    kubernetes_io:jobset_uptime{
+      monitored_resource="k8s_entity",
+      cluster_name="<cluster_name>"
+    }
+  )
+)
+```

--- a/pkg/tools/monitoring/schemas/k8s_node.md
+++ b/pkg/tools/monitoring/schemas/k8s_node.md
@@ -1,0 +1,108 @@
+# Kubernetes Node Resource Schema
+
+The `k8s_node` monitored resource represents a Kubernetes node instance.
+
+See [Monitored resource types](https://cloud.google.com/monitoring/api/resources) for the full list of GKE resource schemas.
+
+## Schema
+
+- Resource type: `k8s_node`
+- Display name: Kubernetes Node
+- Description: A Kubernetes node instance.
+
+## Labels
+
+- `project_id`: The GCP project ID associated with the cluster.
+- `location`: The cluster location (region or zone).
+- `cluster_name`: The cluster name.
+- `node_name`: The node name.
+
+## Sample queries
+
+### Top nodes by CPU cores used
+
+```promql
+topk(
+  10,
+  avg by (node_name) (
+    rate(
+      kubernetes_io:node_cpu_core_usage_time{
+        monitored_resource="k8s_node",
+        cluster_name="<cluster_name>"
+      }[1m]
+    )
+  )
+)
+```
+
+### Nodes with high CPU allocatable utilization
+
+```promql
+topk(
+  10,
+  avg by (node_name) (
+    kubernetes_io:node_cpu_allocatable_utilization{
+      monitored_resource="k8s_node",
+      cluster_name="<cluster_name>"
+    }
+  )
+)
+```
+
+### Top nodes by non-evictable memory usage
+
+```promql
+topk(
+  10,
+  avg by (node_name) (
+    kubernetes_io:node_memory_used_bytes{
+      monitored_resource="k8s_node",
+      cluster_name="<cluster_name>",
+      memory_type="non-evictable"
+    }
+  )
+)
+```
+
+### Top nodes by network receive throughput
+
+```promql
+topk(
+  10,
+  sum by (node_name) (
+    rate(
+      kubernetes_io:node_network_received_bytes_count{
+        monitored_resource="k8s_node",
+        cluster_name="<cluster_name>"
+      }[1m]
+    )
+  )
+)
+```
+
+### Top nodes by ephemeral storage usage
+
+```promql
+topk(
+  10,
+  avg by (node_name) (
+    kubernetes_io:node_ephemeral_storage_used_bytes{
+      monitored_resource="k8s_node",
+      cluster_name="<cluster_name>"
+    }
+  )
+)
+```
+
+### Nodes interrupted in the last hour
+
+```promql
+sum by (node_name) (
+  max_over_time(
+    kubernetes_io:node_interruption_count{
+      monitored_resource="k8s_node",
+      cluster_name="<cluster_name>"
+    }[1h]
+  )
+) > 0
+```

--- a/pkg/tools/monitoring/schemas/k8s_node_pool.md
+++ b/pkg/tools/monitoring/schemas/k8s_node_pool.md
@@ -1,0 +1,74 @@
+# Kubernetes Node Pool Resource Schema
+
+The `k8s_node_pool` monitored resource represents a GKE node pool.
+
+See [Monitored resource types](https://cloud.google.com/monitoring/api/resources) for the full list of GKE resource schemas.
+
+## Schema
+
+- Resource type: `k8s_node_pool`
+- Display name: Kubernetes Nodepool
+- Description: A Kubernetes nodepool instance.
+
+## Labels
+
+- `project_id`: The GCP project ID associated with the cluster.
+- `location`: The cluster location (region or zone).
+- `cluster_name`: The cluster name.
+- `node_pool_name`: The node pool name.
+
+## Sample queries
+
+### Node pool interruption count (last hour)
+
+```promql
+sort_desc(
+  sum by (node_pool_name) (
+    sum_over_time(
+      kubernetes_io:node_pool_interruption_count{
+        monitored_resource="k8s_node_pool",
+        cluster_name="<cluster_name>"
+      }[1h]
+    )
+  )
+)
+```
+
+### Node pool status overview
+
+```promql
+max by (node_pool_name) (
+  kubernetes_io:node_pool_status{
+    monitored_resource="k8s_node_pool",
+    cluster_name="<cluster_name>"
+  }
+)
+```
+
+### Accelerator time to recover (p95)
+
+```promql
+topk(
+  10,
+  histogram_quantile(
+    0.95,
+    sum by (le, node_pool_name) (
+      kubernetes_io:node_pool_accelerator_times_to_recover_bucket{
+        monitored_resource="k8s_node_pool",
+        cluster_name="<cluster_name>"
+      }
+    )
+  )
+)
+```
+
+### Multi-host availability by node pool
+
+```promql
+min by (node_pool_name) (
+  kubernetes_io:node_pool_multi_host_available{
+    monitored_resource="k8s_node_pool",
+    cluster_name="<cluster_name>"
+  }
+)
+```

--- a/pkg/tools/monitoring/schemas/k8s_pod.md
+++ b/pkg/tools/monitoring/schemas/k8s_pod.md
@@ -1,0 +1,111 @@
+# Kubernetes Pod Resource Schema
+
+The `k8s_pod` monitored resource represents a Kubernetes pod instance.
+
+See [Monitored resource types](https://cloud.google.com/monitoring/api/resources) for the full list of GKE resource schemas.
+
+## Schema
+
+- Resource type: `k8s_pod`
+- Display name: Kubernetes Pod
+- Description: A Kubernetes pod instance.
+
+## Labels
+
+- `project_id`: The GCP project ID associated with the cluster.
+- `location`: The cluster location (region or zone).
+- `cluster_name`: The cluster name.
+- `namespace_name`: The namespace the pod is running in.
+- `pod_name`: The pod name.
+
+## Sample queries
+
+### Top pods by network receive throughput
+
+```promql
+topk(
+  10,
+  sum by (namespace_name, pod_name) (
+    rate(
+      kubernetes_io:pod_network_received_bytes_count{
+        monitored_resource="k8s_pod",
+        cluster_name="<cluster_name>",
+        interface="eth0"
+      }[1m]
+    )
+  )
+)
+```
+
+### Top pods by network send throughput
+
+```promql
+topk(
+  10,
+  sum by (namespace_name, pod_name) (
+    rate(
+      kubernetes_io:pod_network_sent_bytes_count{
+        monitored_resource="k8s_pod",
+        cluster_name="<cluster_name>",
+        interface="eth0"
+      }[1m]
+    )
+  )
+)
+```
+
+### Pods with high volume utilization
+
+```promql
+topk(
+  10,
+  max by (namespace_name, pod_name) (
+    kubernetes_io:pod_volume_utilization{
+      monitored_resource="k8s_pod",
+      cluster_name="<cluster_name>"
+    }
+  )
+)
+```
+
+### Top pods by ephemeral storage usage
+
+```promql
+topk(
+  10,
+  avg by (namespace_name, pod_name) (
+    kubernetes_io:pod_ephemeral_storage_used_bytes{
+      monitored_resource="k8s_pod",
+      cluster_name="<cluster_name>"
+    }
+  )
+)
+```
+
+### Slowest pod startup (pod first ready latency p95)
+
+```promql
+topk(
+  10,
+  quantile_over_time(
+    0.95,
+    kubernetes_io:pod_latencies_pod_first_ready{
+      monitored_resource="k8s_pod",
+      cluster_name="<cluster_name>"
+    }[5m]
+  )
+)
+```
+
+### Network policy events in the last 5 minutes
+
+```promql
+sum by (namespace_name, pod_name) (
+  increase(
+    kubernetes_io:pod_network_policy_event_count{
+      monitored_resource="k8s_pod",
+      cluster_name="<cluster_name>"
+    }[5m]
+  )
+) > 0
+```

--- a/pkg/tools/monitoring/schemas/k8s_scale.md
+++ b/pkg/tools/monitoring/schemas/k8s_scale.md
@@ -1,0 +1,66 @@
+# Kubernetes Scale Resource Schema
+
+The `k8s_scale` monitored resource represents a Kubernetes object that can be targeted by autoscalers.
+
+See [Monitored resource types](https://cloud.google.com/monitoring/api/resources) for the full list of GKE resource schemas.
+
+## Schema
+
+- Resource type: `k8s_scale`
+- Display name: Kubernetes Scale
+- Description: A Kubernetes object that can be targeted by Kubernetes autoscalers.
+
+## Labels
+
+- `project_id`: The GCP project ID associated with the cluster.
+- `location`: The cluster location (region or zone).
+- `cluster_name`: The cluster name.
+- `namespace_name`: The namespace containing the scaled object.
+- `controller_api_group_name`: The API group of the scaled object, for example `core`.
+- `controller_kind`: The kind of the scaled object, for example `Deployment`.
+- `controller_name`: The name of the scaled object.
+
+## Sample queries
+
+### HPA recommended CPU request per replica
+
+```promql
+topk(
+  10,
+  avg by (namespace_name, controller_name) (
+    kubernetes_io:autoscaler_container_cpu_per_replica_recommended_request_cores{
+      monitored_resource="k8s_scale",
+      cluster_name="<cluster_name>"
+    }
+  )
+)
+```
+
+### HPA recommended memory request per replica
+
+```promql
+topk(
+  10,
+  avg by (namespace_name, controller_name) (
+    kubernetes_io:autoscaler_container_memory_per_replica_recommended_request_bytes{
+      monitored_resource="k8s_scale",
+      cluster_name="<cluster_name>"
+    }
+  )
+)
+```
+
+### HPA recommendation latency (p95)
+
+```promql
+topk(
+  10,
+  quantile_over_time(
+    0.95,
+    kubernetes_io:autoscaler_latencies_per_hpa_recommendation_scale_latency_seconds{
+      monitored_resource="k8s_scale",
+      cluster_name="<cluster_name>"
+    }[5m]
+  )
+)
+```

--- a/pkg/tools/monitoring/schemas/k8s_service.md
+++ b/pkg/tools/monitoring/schemas/k8s_service.md
@@ -1,0 +1,92 @@
+# Kubernetes Service Resource Schema
+
+The `k8s_service` monitored resource represents a Kubernetes Service instance.
+
+See [Monitored resource types](https://cloud.google.com/monitoring/api/resources) for the full list of GKE resource schemas.
+
+## Schema
+
+- Resource type: `k8s_service`
+- Display name: Kubernetes Service
+- Description: A Kubernetes Service instance.
+
+## Labels
+
+- `project_id`: The GCP project ID associated with the cluster.
+- `location`: The cluster location (region or zone).
+- `cluster_name`: The cluster name.
+- `namespace_name`: The namespace the service is running in.
+- `service_name`: The service name.
+
+## Sample queries
+
+Service-level metrics often come from service mesh, ingress, or application
+instrumentation. Replace the placeholder metric names below with the PromQL
+metric names you collect for request count, latency, and error rate.
+
+### Service request rate
+
+```promql
+topk(
+  10,
+  sum by (namespace_name, service_name) (
+    rate(
+      <request_count_metric>{
+        monitored_resource="k8s_service",
+        cluster_name="<cluster_name>"
+      }[1m]
+    )
+  )
+)
+```
+
+### Service request latency p95
+
+```promql
+topk(
+  10,
+  histogram_quantile(
+    0.95,
+    sum by (le, namespace_name, service_name) (
+      rate(
+        <request_latency_metric>_bucket{
+          monitored_resource="k8s_service",
+          cluster_name="<cluster_name>"
+        }[5m]
+      )
+    )
+  )
+)
+```
+
+### Service error rate
+
+```promql
+topk(
+  10,
+  sum by (namespace_name, service_name) (
+    rate(
+      <error_count_metric>{
+        monitored_resource="k8s_service",
+        cluster_name="<cluster_name>"
+      }[1m]
+    )
+  )
+)
+```
+
+### Service throughput (bytes sent)
+
+```promql
+topk(
+  10,
+  sum by (namespace_name, service_name) (
+    rate(
+      <response_bytes_metric>{
+        monitored_resource="k8s_service",
+        cluster_name="<cluster_name>"
+      }[1m]
+    )
+  )
+)
+```


### PR DESCRIPTION
## Summary
- expose get_metric_schema for GKE monitored resource schemas used in metrics queries
- add schema docs for core Kubernetes/GKE resource types (cluster, node, node pool, pod, container, control plane component, service, scale, entity)
- add unit test coverage for schema lookup

## Details
- validate supported resource types and map to embedded schema markdowns
- document resource labels and example MQL filters based on the Monitoring resources catalog

## References
- https://cloud.google.com/monitoring/api/resources

## Testing
- go test ./pkg/tools/monitoring
