### PR TITLE
Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,89 @@
+# Dependabot configuration for automated dependency updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Go module dependencies
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "go"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    reviewers:
+      - "GoogleCloudPlatform/gke-mcp-owners"
+    # Group minor and patch updates together to reduce PR noise
+    groups:
+      google-cloud:
+        patterns:
+          - "cloud.google.com/*"
+        update-types:
+          - "minor"
+          - "patch"
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+        update-types:
+          - "minor"
+          - "patch"
+      opentelemetry:
+        patterns:
+          - "go.opentelemetry.io/*"
+        update-types:
+          - "minor"
+          - "patch"
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
+        update-types:
+          - "minor"
+          - "patch"
+      protobuf-grpc:
+        patterns:
+          - "google.golang.org/protobuf"
+          - "google.golang.org/grpc"
+          - "google.golang.org/genproto*"
+          - "google.golang.org/api"
+        update-types:
+          - "minor"
+          - "patch"
+    # Ignore specific dependencies if needed
+    ignore:
+      # Ignore major version updates for stable dependencies
+      # Uncomment to ignore specific packages:
+      # - dependency-name: "k8s.io/client-go"
+      #   update-types: ["version-update:semver-major"]
+
+  # GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    reviewers:
+      - "GoogleCloudPlatform/gke-mcp-owners"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## 🎯 Why This Change?

This PR adds Dependabot configuration to automate dependency updates. Currently, the repository has several issues with dependency management:

- **20+ outdated dependencies**: Analysis shows multiple dependencies with available updates (cel.dev/expr, cloud.google.com packages, kubernetes libraries, etc.)
- **Security vulnerabilities**: Outdated dependencies may contain known security issues
- **Manual update burden**: Maintainers must manually track and update dependencies
- **No automated security patches**: Critical security updates require manual intervention

Without automated dependency management, the project risks:
- Running outdated, potentially vulnerable code
- Missing important bug fixes and performance improvements
- Increased maintenance burden on contributors
- Slower response to security advisories

## 📝 What's Changed?

This PR adds a single new file:

### `.github/dependabot.yml`

A comprehensive Dependabot configuration that:

1. **Go Module Updates** (weekly on Mondays)
   - Monitors all Go dependencies in `go.mod`
   - Groups related dependencies to reduce PR noise:
     - Google Cloud packages (`cloud.google.com/*`)
     - Kubernetes packages (`k8s.io/*`, `sigs.k8s.io/*`)
     - OpenTelemetry packages (`go.opentelemetry.io/*`)
     - Go standard extensions (`golang.org/x/*`)
     - Protobuf/gRPC packages (`google.golang.org/*`)
   - Limits to 10 open PRs max to avoid overwhelming maintainers

2. **GitHub Actions Updates** (weekly on Mondays)
   - Monitors workflow dependencies (actions/checkout, actions/setup-go, etc.)
   - Groups all GitHub Actions updates together
   - Limits to 5 open PRs max

3. **Smart Configuration**
   - Uses conventional commit prefixes (`deps:`, `ci:`)
   - Auto-assigns to code owners (@GoogleCloudPlatform/gke-mcp-owners)
   - Auto-labels PRs (`dependencies`, `go`, `github-actions`)
   - Schedules updates for Monday mornings (PST) to align with work week

## ✅ Benefits

### Security
- **Automated security patches**: Critical vulnerabilities get fixed automatically
- **Faster response**: No waiting for manual dependency reviews
- **Proactive updates**: Stay ahead of security advisories

### Maintenance
- **Reduced manual work**: No more manual dependency tracking
- **Grouped updates**: Minor/patch updates bundled together (fewer PRs)
- **Clear visibility**: Easy to see what changed in each dependency group

### Quality
- **Bug fixes**: Automatically pick up bug fixes from dependencies
- **Performance**: Get performance improvements from updated libraries
- **Compatibility**: Stay compatible with evolving ecosystems (K8s, GCP)

## 📊 Current State

Dependencies with available updates (sample):
```
cel.dev/expr v0.24.0 → v0.25.1
cloud.google.com/go/firestore v1.20.0 → v1.21.0
cloud.google.com/go/kms v1.23.2 → v1.24.0
cloud.google.com/go/storage v1.56.0 → v1.59.1
github.com/golang-jwt/jwt/v5 v5.2.2 → v5.3.0
github.com/emicklei/go-restful/v3 v3.12.2 → v3.13.0
... (and 15+ more)
```

## 🔄 What Happens Next?

Once merged:
1. Dependabot will start scanning dependencies weekly
2. It will create grouped PRs for available updates
3. Each PR will include:
   - Changelog information
   - Compatibility notes
   - Release notes from updated packages
4. Maintainers review and merge (or close) as appropriate
5. GitHub Security alerts will trigger immediate PRs for vulnerabilities

## 📋 Checklist

- [x] Created `.github/dependabot.yml` following best practices
- [x] Configured both `gomod` and `github-actions` ecosystems
- [x] Set up intelligent grouping to reduce PR noise
- [x] Limited open PRs to prevent overwhelming maintainers
- [x] Added proper labels and commit message conventions
- [x] Assigned to code owners for review
- [x] Tested configuration syntax (valid YAML)

## 🔗 References

- [Dependabot Documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)
- [Dependabot Best Practices](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)
- [GitHub Security Best Practices](https://docs.github.com/en/code-security/getting-started/securing-your-repository)

---

**Note**: This is a configuration-only change with no code modifications. The first Dependabot PRs will appear within 24 hours of merging, but maintainers have full control to review, merge, or close them.