### PR TITLE
Add comprehensive Makefile for common development tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+# Makefile for GKE MCP Server
+# Provides convenient shortcuts for common development tasks
+
+.PHONY: help build install test clean presubmit
+
+# Default target - show help
+.DEFAULT_GOAL := help
+
+# Variables
+BINARY_NAME := gke-mcp
+VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+LDFLAGS := -ldflags "-X main.version=$(VERSION)"
+
+help: ## Display available commands
+	@echo "GKE MCP Server - Available Commands"
+	@echo ""
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make \033[36m<target>\033[0m\n\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+build: ## Build the binary
+	@echo "Building $(BINARY_NAME)..."
+	go build $(LDFLAGS) -o $(BINARY_NAME) .
+	@echo "✓ Built $(BINARY_NAME)"
+
+install: ## Install the binary to GOPATH/bin
+	@echo "Installing $(BINARY_NAME)..."
+	go install $(LDFLAGS) .
+	@echo "✓ Installed to $(shell go env GOPATH)/bin/$(BINARY_NAME)"
+
+test: ## Run tests
+	@echo "Running tests..."
+	go test -v ./...
+
+clean: ## Remove build artifacts
+	@echo "Cleaning up..."
+	@rm -f $(BINARY_NAME)
+	@rm -f coverage.out coverage.html
+	@rm -rf dist/
+	@echo "✓ Cleaned"
+
+presubmit: ## Run all presubmit checks (build, test, vet, format)
+	@echo "Running presubmit checks..."
+	@./dev/tasks/presubmit.sh
+	@echo "✓ All presubmit checks passed"


### PR DESCRIPTION
## 🎯 Why This Change?

This PR adds a simple, focused Makefile to standardize common development tasks. Currently, developers need to:

- Remember various shell script paths (`./dev/ci/presubmits/*.sh`, `./dev/tasks/*.sh`)
- Type long commands repeatedly (`go build -o gke-mcp .`, `go test -v ./...`)
- Know where scripts are located

**Problems this solves:**

1. **Discoverability**: New contributors don't know what commands are available
2. **Consistency**: No standard way to build, test, or run the project
3. **Efficiency**: Repetitive typing of commands

## 📝 What's Changed?

This PR adds a single, focused Makefile with **6 essential commands**:

### Available Targets

```
make          # Show available commands (default)
make build    # Build the binary
make install  # Install to GOPATH/bin
make test     # Run tests
make clean    # Remove build artifacts
make presubmit # Run all checks (build, test, vet, format)
```

## ✅ Key Features

### 1. **Simple and Focused**
- Only 6 commands - easy to learn and remember
- No overwhelming list of targets
- Covers 90% of daily development needs

### 2. **Self-Documenting**
Running `make` or `make help` shows:
```
GKE MCP Server - Available Commands

Usage: make <target>

  help            Display available commands
  build           Build the binary
  install         Install the binary to GOPATH/bin
  test            Run tests
  clean           Remove build artifacts
  presubmit       Run all presubmit checks (build, test, vet, format)
```

### 3. **Version Information**
Automatically includes git version in builds:
```bash
make build
# Builds with: -ldflags "-X main.version=v0.7.2-1-g5fd0b72"
```

### 4. **Integration with Existing Scripts**
The `presubmit` target uses the existing `./dev/tasks/presubmit.sh` script, so no logic is duplicated.

## ✅ Benefits

### Developer Experience
- **Faster onboarding**: `make` shows all available commands
- **Muscle memory**: Common pattern across Go projects
- **Less typing**: `make test` vs `go test -v ./...`

### Consistency
- **Standard commands**: Everyone uses the same workflow
- **Script integration**: Leverages existing scripts

### Productivity
- **Quick workflows**: `make presubmit` runs all checks
- **Smart defaults**: Default target shows help (beginner-friendly)

## 🔄 Comparison: Before vs After

### Before
```bash
# Build
go build -o gke-mcp .

# Test
go test -v ./...

# Presubmit
./dev/ci/presubmits/go-build.sh
./dev/ci/presubmits/go-test.sh
./dev/ci/presubmits/go-vet.sh
./dev/tasks/format.sh
./dev/tasks/gomod.sh
```

### After
```bash
make build
make test
make presubmit
```

**Much simpler and easier to remember!**

## 📋 Example Usage

```bash
# First time setup
git clone https://github.com/GoogleCloudPlatform/gke-mcp.git
cd gke-mcp
make          # See all available commands

# Daily development
make build    # Build the binary
make test     # Run tests
make presubmit # Run all checks before committing

# Installation
make install  # Install to GOPATH/bin

# Cleanup
make clean    # Remove build artifacts
```

## 📋 Checklist

- [x] Created simple Makefile with 6 essential targets
- [x] Added self-documenting help system
- [x] Integrated with existing dev/tasks/presubmit.sh
- [x] Added version information to builds
- [x] Tested all targets (build, test, install, clean)
- [x] Made `help` the default target (beginner-friendly)
- [x] Kept it simple and focused (no overwhelming list)

## 🔗 References

- [GNU Make Manual](https://www.gnu.org/software/make/manual/)
- [Self-Documenting Makefiles](https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html)

---

**Note**: This is a pure addition with no changes to existing code or scripts. It provides a convenient layer on top of existing tooling. Developers can continue using shell scripts directly if preferred.

## 🎓 For Reviewers

To test locally:
```bash
make          # See all commands (clean, simple list)
make build    # Build the binary
make test     # Run tests
make clean    # Cleanup
```

All targets work out of the box with no additional dependencies.