### PR TITLE
Fix gofmt: simplify composite literal

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -173,7 +173,7 @@ func startMCPServer(ctx context.Context, opts startOptions) {
 	s.AddResource(resource, func(_ context.Context, _ *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
 		return &mcp.ReadResourceResult{
 			Contents: []*mcp.ResourceContents{
-				&mcp.ResourceContents{
+				{
 					URI:      geminiInstructionsURI,
 					MIMEType: "text/markdown",
 					Text:     string(install.GeminiMarkdown),


### PR DESCRIPTION
## 🎯 Why This Change?

This PR fixes a code formatting issue identified by `gofmt`, bringing the code in line with Go's official style guidelines.

## 📝 What Changed?

**File:** `cmd/root.go:176`

**Issue:** Redundant type declaration in composite literal

**Fix:** Simplified the composite literal by removing the redundant type:

```diff
  return &mcp.ReadResourceResult{
      Contents: []*mcp.ResourceContents{
-         &mcp.ResourceContents{
+         {
              URI:      geminiInstructionsURI,
              MIMEType: "text/markdown",
              Text:     string(install.GeminiMarkdown),
          },
      },
  }, nil
```

## ✅ Why This Matters

### 1. **Follows Go Style Guide**
   - Go's official style guide recommends omitting redundant types in composite literals
   - The type can be inferred from the context (`[]*mcp.ResourceContents`)

### 2. **Cleaner, More Readable Code**
   - Reduces visual clutter
   - Makes the code more idiomatic Go

### 3. **Consistency**
   - Ensures code passes `gofmt -s` (simplify) checks
   - Aligns with standard Go tooling expectations

## 🔗 Context

This is **part of a larger effort** to enable `golangci-lint` in CI (PR #151). That PR added the linting configuration but temporarily disabled the CI job until existing issues are fixed.

**Progress:** This PR resolves **1 of 162** golangci-lint issues.

**Related PRs:**
- PR #151: Added golangci-lint configuration (merged, CI disabled)
- Follow-up PRs will fix remaining issues:
  - errcheck (29 issues)
  - gosec (56 issues)
  - revive (76 issues)

## ✅ Testing

```bash
# Verified formatting is correct
gofmt -s -d cmd/root.go  # No output (correctly formatted)

# Verified code still builds
go build -o gke-mcp .  # Success

# Verified tests still pass
go test -v ./...  # All pass
```

## 📚 References

- [Effective Go - Composite Literals](https://go.dev/doc/effective_go#composite_literals)
- [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments#gofmt)

---

**This is a pure formatting change with no functional impact.**