### PR TITLE
fix: model-and-server-combinations is only in alpha release track

### DIFF
--- a/skills/gke-inference-quickstart/SKILL.md
+++ b/skills/gke-inference-quickstart/SKILL.md
@@ -36,7 +36,7 @@ gcloud container ai profiles models list
 
 ```bash
 # Replace <MODEL_NAME> with a model from the list above (e.g., 'gemma-2-9b-it')
-gcloud alpha container ai profiles model-and-server-combinations list --model=<MODEL_NAME>
+gcloud container ai profiles list --model=<MODEL_NAME>
 ```
 
 **View benchmarks/profiles (optional):**

--- a/skills/gke-inference-quickstart/SKILL.md
+++ b/skills/gke-inference-quickstart/SKILL.md
@@ -36,7 +36,7 @@ gcloud container ai profiles models list
 
 ```bash
 # Replace <MODEL_NAME> with a model from the list above (e.g., 'gemma-2-9b-it')
-gcloud container ai profiles model-and-server-combinations list --model=<MODEL_NAME>
+gcloud alpha container ai profiles model-and-server-combinations list --model=<MODEL_NAME>
 ```
 
 **View benchmarks/profiles (optional):**


### PR DESCRIPTION
Fixes this error:

```
$ gcloud container ai profiles model-and-server-combinations list
ERROR: (gcloud.container.ai.profiles) Invalid choice: 'model-and-server-combinations'.
This command is available in one or more alternate release tracks.  Try:
  gcloud alpha container ai profiles model-and-server-combinations
```

Most Agents will fix this on their own, but it adds extra time.