### PR TITLE
chore: Bump version to 0.9.0

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -7,5 +7,5 @@
     }
   },
   "name": "gke-mcp",
-  "version": "0.8.0"
+  "version": "0.9.0"
 }


### PR DESCRIPTION
## 📝 What Changed?

**File:** `gemini-extension.json`

**Issue:** Routine version bump

**Fix:** Updated the minor version of the extension from `0.8.0` to `0.9.0`

```diff
- "version": "0.8.0"
+ "version": "0.9.0"
```

## ✅ Why This Matters

### 1. **Releases**
   - Keeps the repository version aligned with new features and fixes.
   - Triggers new release build processes if applicable.

## ✅ Testing

```bash
# Verified presubmit tests pass
./dev/tasks/presubmit.sh  # All pass
```

---

**This is a version configuration change with no functional code impact.**
