### PR TITLE
build: Remove version override step in release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,14 +33,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Extract version from tag
-        id: get_version
-        run: echo "VERSION=$(echo ${{ github.ref }} | sed 's/refs\/tags\///')" >> "$GITHUB_OUTPUT"
-
-      - name: Update version in file
-        run: |
-          sed "s/\"version\": .*/\"version\": \"${{ steps.get_version.outputs.VERSION }}\"/g;s/: \"v/: \"/g" gemini-extension.json > gemini-extension.json.out
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,8 +43,7 @@ archives:
         formats: [zip]
     files:
       - LICENSE
-      - src: gemini-extension.json.out
-        dst: gemini-extension.json
+      - src: gemini-extension.json
       - src: pkg/install/GEMINI.md
         strip_parent: true
 


### PR DESCRIPTION
## 📝 What Changed?

**Files:**
- `.github/workflows/release.yaml`
- `.goreleaser.yaml`

**Issue:** Version overriding step was hardcoded and tightly coupled to git tags, which could cause issues during release processes.

**Fix:** Removed the `Extract version from tag` and `Update version in file` steps from `.github/workflows/release.yaml`, and updated `.goreleaser.yaml` to include `gemini-extension.json` directly instead of the `.out` file.

## ✅ Why This Matters

### 1. **Cleaner Release Process**
   - Streamlines the release automation.
   - Version should be managed within the repository (e.g., via minor version bumps) instead of string replacement in the pipeline.
  
This is possible because of the release changes in #165.

## ✅ Testing

```bash
# Verified presubmit tests pass
./dev/tasks/presubmit.sh  # All pass
```
