### PR TITLE
ci: add permissions for super-linter to write PR comments

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -148,9 +148,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
+      # contents permission to clone the repository
       contents: read
       packages: read
-      # To report GitHub Actions status checks
+      # issues and pull-requests permissions to write results as pull
+      # request comments. Omit them if you don't need summary comments
+      issues: write
+      pull-requests: write
+      # To report GitHub Actions status checks. Omit if you don't need
+      # to update commit status
       statuses: write
     steps:
       - uses: actions/checkout@v4
@@ -158,6 +164,7 @@ jobs:
           # super-linter needs the full git history to get the
           # list of files that changed across commits
           fetch-depth: 0
+          persist-credentials: false
       - name: "Super-linter"
         uses: super-linter/super-linter/slim@v8.5.0
         env:


### PR DESCRIPTION
🎯 Why This Change?
Super-linter needs write permissions for issues and pull-requests to be able to post summary comments on pull requests with linting results. This change grants those permissions to the `super-linter` job in the presubmit workflow. It also sets `persist-credentials: false` on the checkout step as a security best practice.

📝 What Changed?
File: `.github/workflows/presubmit.yaml`
- Added `issues: write` and `pull-requests: write` permissions to the job.
- Added `persist-credentials: false` to the `actions/checkout` step.

## ✅ Testing
- Verified that `./dev/tasks/presubmit.sh` passes on an isolated branch created from `main`.

## 📚 References
- Super-linter documentation for PR comments feature.
