### PR TITLE
Add skills validation and fix missing frontmatter

### DIFF
--- a/dev/ci/presubmits/validate-skills.sh
+++ b/dev/ci/presubmits/validate-skills.sh
@@ -48,8 +48,8 @@ for skill_dir in skills/*; do
                 continue
             fi
             
-            if ! echo "$fm_content" | grep -q "^name:"; then
-                echo "Error: $skill_file is missing 'name' in frontmatter"
+            if ! echo "$fm_content" | grep -q "^name:[[:space:]]*[^[:space:]]"; then
+                echo "Error: $skill_file is missing a non-empty 'name' in frontmatter"
                 failed=1
             fi
             

--- a/dev/ci/presubmits/validate-skills.sh
+++ b/dev/ci/presubmits/validate-skills.sh
@@ -53,8 +53,8 @@ for skill_dir in skills/*; do
                 failed=1
             fi
             
-            if ! echo "$fm_content" | grep -q "^description:"; then
-                echo "Error: $skill_file is missing 'description' in frontmatter"
+            if ! echo "$fm_content" | grep -q "^description:[[:space:]]*[^[:space:]]"; then
+                echo "Error: $skill_file is missing a non-empty 'description' in frontmatter"
                 failed=1
             fi
             

--- a/dev/ci/presubmits/validate-skills.sh
+++ b/dev/ci/presubmits/validate-skills.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+failed=0
+
+for skill_dir in skills/*; do
+    if [ -d "$skill_dir" ]; then
+        skill_file="$skill_dir/SKILL.md"
+        if [ -f "$skill_file" ]; then
+            # Check if file starts with ---
+            if ! head -n 1 "$skill_file" | grep -q "^---$"; then
+                echo "Error: $skill_file does not start with ---"
+                failed=1
+                continue
+            fi
+            
+            # Extract frontmatter content (between first and second ---)
+            fm_content=$(awk '
+                BEGIN { count=0; content="" }
+                /^---$/ { count++; next }
+                count==1 { content = content $0 "\n" }
+                count==2 { exit }
+                END { if (count >= 2) printf "%s", content }
+            ' "$skill_file")
+            
+            if [ -z "$fm_content" ]; then
+                echo "Error: $skill_file has empty or invalid frontmatter (missing closing ---?)"
+                failed=1
+                continue
+            fi
+            
+            if ! echo "$fm_content" | grep -q "^name:"; then
+                echo "Error: $skill_file is missing 'name' in frontmatter"
+                failed=1
+            fi
+            
+            if ! echo "$fm_content" | grep -q "^description:"; then
+                echo "Error: $skill_file is missing 'description' in frontmatter"
+                failed=1
+            fi
+            
+        else
+            echo "Error: Missing SKILL.md in $skill_dir"
+            failed=1
+        fi
+    fi
+done
+
+if [ $failed -ne 0 ]; then
+    echo "Skills validation failed."
+    exit 1
+fi
+
+echo "All skills validated successfully."

--- a/dev/tasks/presubmit.sh
+++ b/dev/tasks/presubmit.sh
@@ -43,6 +43,7 @@ run_task "./dev/ci/presubmits/go-build.sh"
 run_task "./dev/ci/presubmits/go-test.sh"
 run_task "./dev/ci/presubmits/go-vet.sh"
 run_task "./dev/ci/presubmits/docker-build.sh"
+run_task "./dev/ci/presubmits/validate-skills.sh"
 
 # Run golangci-lint if available
 if command -v golangci-lint &> /dev/null; then

--- a/skills/gke-cluster-lifecycle/SKILL.md
+++ b/skills/gke-cluster-lifecycle/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: GKE Cluster Lifecycle and Upgrades
+description: Guidance on managing the lifecycle and upgrades of GKE clusters.
+---
+
 # GKE Cluster Lifecycle and Upgrades
 
 This skill provides guidance on managing the lifecycle and upgrades of Google Kubernetes Engine (GKE) clusters.

--- a/skills/gke-cost-optimization/SKILL.md
+++ b/skills/gke-cost-optimization/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: GKE Cost Optimization
+description: Guidance on optimizing costs for GKE clusters.
+---
+
 # GKE Cost Optimization
 
 This skill provides guidance on optimizing costs for Google Kubernetes Engine (GKE) clusters.

--- a/skills/gke-multi-tenancy/SKILL.md
+++ b/skills/gke-multi-tenancy/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: GKE Multi-tenancy and Governance
+description: Guidance on implementing multi-tenancy and governance in GKE clusters.
+---
+
 # GKE Multi-tenancy and Governance
 
 This skill provides guidance on implementing multi-tenancy and governance in Google Kubernetes Engine (GKE) clusters.

--- a/skills/gke-storage/SKILL.md
+++ b/skills/gke-storage/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: GKE Storage Best Practices
+description: Guidance on managing storage in GKE clusters.
+---
+
 # GKE Storage Best Practices
 
 This skill provides guidance on managing storage in Google Kubernetes Engine (GKE) clusters.


### PR DESCRIPTION
## Summary
This PR adds a script to validate that all Agent Skills in the `skills/` directory have the required frontmatter (`name` and `description`). It also integrates this script into the local presubmit checks.

## Rationale
To ensure consistency and discoverability of Agent Skills, they should have a standard frontmatter. This test prevents skills from being added without this metadata.

## Changes
- Added `dev/ci/presubmits/validate-skills.sh` to check for frontmatter.
- Modified `dev/tasks/presubmit.sh` to run the new validation script.

## Verification Results
- Ran `./dev/tasks/presubmit.sh` and verified that all skills passed.
