### PR TITLE
feat: ensure skill names match directory names

### DIFF
--- a/dev/ci/presubmits/validate-skills.sh
+++ b/dev/ci/presubmits/validate-skills.sh
@@ -53,11 +53,13 @@ for skill_dir in skills/*; do
                 failed=1
             fi
 
-            skill_name=$(echo "$fm_content" | grep "^name:" | sed 's/^name:[[:space:]]*//')
-            dir_name=$(basename "$skill_dir")
-            if [ "$skill_name" != "$dir_name" ]; then
-                echo "Error: Skill name '$skill_name' does not match directory name '$dir_name' in $skill_file"
-                failed=1
+            if echo "$fm_content" | grep -q "^name:"; then
+                skill_name=$(echo "$fm_content" | grep "^name:" | sed 's/^name:[[:space:]]*//' | xargs)
+                dir_name=$(basename "$skill_dir")
+                if [ "$skill_name" != "$dir_name" ]; then
+                    echo "Error: Skill name '$skill_name' does not match directory name '$dir_name' in $skill_file"
+                    failed=1
+                fi
             fi
             
             if ! echo "$fm_content" | grep -q "^description:[[:space:]]*[^[:space:]]"; then

--- a/dev/ci/presubmits/validate-skills.sh
+++ b/dev/ci/presubmits/validate-skills.sh
@@ -52,6 +52,13 @@ for skill_dir in skills/*; do
                 echo "Error: $skill_file is missing a non-empty 'name' in frontmatter"
                 failed=1
             fi
+
+            skill_name=$(echo "$fm_content" | grep "^name:" | sed 's/^name:[[:space:]]*//')
+            dir_name=$(basename "$skill_dir")
+            if [ "$skill_name" != "$dir_name" ]; then
+                echo "Error: Skill name '$skill_name' does not match directory name '$dir_name' in $skill_file"
+                failed=1
+            fi
             
             if ! echo "$fm_content" | grep -q "^description:[[:space:]]*[^[:space:]]"; then
                 echo "Error: $skill_file is missing a non-empty 'description' in frontmatter"

--- a/skills/gke-cluster-creator/SKILL.md
+++ b/skills/gke-cluster-creator/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: gke-creation
+name: gke-cluster-creator
 description: Guides the user through creating GKE clusters using pre-defined templates (Standard, Autopilot, GPU/AI).
 ---
 


### PR DESCRIPTION
## 🎯 Why This Change?
This PR ensures that all GKE skills follow a consistent naming convention where the `name` field in the `SKILL.md` frontmatter matches its parent directory name. This improves maintainability and avoids confusion.

## 📝 What Changed?
- Corrected the `name` field in `skills/gke-cluster-creator/SKILL.md` from `gke-creation` to `gke-cluster-creator`.
- Updated `dev/ci/presubmits/validate-skills.sh` to enforce that the skill name matches the directory name.

### 1. Consistency
- Ensures all skills are named predictably based on their directory.

### 2. Automation
- Prevents future mismatches by adding a check to the presubmit script.

## 🔗 Context
This was requested to standardize skill metadata.

## ✅ Testing
- Verified that `dev/ci/presubmits/validate-skills.sh` fails when a mismatch is present.
- Verified that all presubmit checks pass.
