### PR TITLE
fix: remove broken ignore block in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,12 +56,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-    # Ignore specific dependencies if needed
-    ignore:
-      # Ignore major version updates for stable dependencies
-      # Uncomment to ignore specific packages:
-      # - dependency-name: "k8s.io/client-go"
-      #   update-types: ["version-update:semver-major"]
 
   # GitHub Actions dependencies
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
# Summary
This PR fixes an error in the Dependabot configuration where the `ignore:` property was left empty (null), causing Dependabot to fail.

## Rationale
Dependabot expects an array for the `ignore` property if it is present. Since all items were commented out, it evaluated to null. Removing the block fixes the error.

## Changes
- `.github/dependabot.yml`: Removed the empty `ignore:` block.

## Verification Results
Local presubmit checks were run and passed successfully:
- Super-linter passed after formatting with Prettier.
