### PR TITLE
feat: add npm to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,6 +74,13 @@ updates:
       include: "scope"
     reviewers:
       - "GoogleCloudPlatform/gke-mcp-owners"
+    groups:
+      all-npm:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions dependencies
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,6 +57,24 @@ updates:
           - "minor"
           - "patch"
 
+  # NPM dependencies
+  - package-ecosystem: "npm"
+    directory: "/ui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    reviewers:
+      - "GoogleCloudPlatform/gke-mcp-owners"
+
   # GitHub Actions dependencies
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
# Add npm to Dependabot configuration

## Summary
This PR adds the `npm` package ecosystem to the Dependabot configuration to enable automated dependency updates for the Node.js application located in the `/ui` directory.

## Rationale
The project has a Node.js application in the `ui` directory with its own `package.json` and dependencies. Adding Dependabot support for `npm` will help keep these dependencies up to date automatically, reducing technical debt and security risks.

## Changes
- Modified `.github/dependabot.yml` to include a new update configuration for `npm` targeting the `/ui` directory.

## Verification
- Verified that `./dev/tasks/presubmit.sh` passes.
