### PR TITLE
feat: update mui dependencies to latest

### DIFF
--- a/ui/apps/dropdown/src/App.tsx
+++ b/ui/apps/dropdown/src/App.tsx
@@ -104,9 +104,11 @@ export default function App() {
             onChange={handleSelect}
             disabled={submitted}
             MenuProps={{
-              PaperProps: {
-                style: {
-                  maxHeight: MENU_ITEMS_MAX_HEIGHT,
+              slotProps: {
+                paper: {
+                  style: {
+                    maxHeight: MENU_ITEMS_MAX_HEIGHT,
+                  },
                 },
               },
             }}

--- a/ui/apps/timeserieschart/src/App.tsx
+++ b/ui/apps/timeserieschart/src/App.tsx
@@ -207,7 +207,7 @@ function App() {
             flexDirection: 'column',
           }}
         >
-          <Typography textAlign="center" color="text.primary">
+          <Typography sx={{ textAlign: 'center' }} color="text.primary">
             {title}
           </Typography>
           <TimeSeriesChart

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,8 +8,8 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@mui/material": "^7.3.9",
-        "@mui/x-charts": "^8.28.0",
+        "@mui/material": "^9.0.0",
+        "@mui/x-charts": "^9.0.1",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "zod": "^4.3.6"
@@ -1267,9 +1267,9 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.9.tgz",
-      "integrity": "sha512-MOkOCTfbMJwLshlBCKJ59V2F/uaLYfmKnN76kksj6jlGUVdI25A9Hzs08m+zjBRdLv+sK7Rqdsefe8X7h/6PCw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-9.0.0.tgz",
+      "integrity": "sha512-uwQNGkhv0lf7ufxw6QXev77BW6pWbW+7uxYjU5+rfp4lBkFtMEgJCsarTM3Tn+i0lGx6+Ol2u88JdGXr0GDskA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -1277,22 +1277,22 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.9.tgz",
-      "integrity": "sha512-I8yO3t4T0y7bvDiR1qhIN6iBWZOTBfVOnmLlM7K6h3dx5YX2a7rnkuXzc2UkZaqhxY9NgTnEbdPlokR1RxCNRQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.0.0.tgz",
+      "integrity": "sha512-+VP/oQCDhDR87NQQgXnNBG8dwy6GNuQLnenS1pZvkbn2dKFSxRSRMybTpH9xUxXP+316mlYDy5CSbYtusnCWtw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/core-downloads-tracker": "^7.3.9",
-        "@mui/system": "^7.3.9",
-        "@mui/types": "^7.4.12",
-        "@mui/utils": "^7.3.9",
+        "@babel/runtime": "^7.29.2",
+        "@mui/core-downloads-tracker": "^9.0.0",
+        "@mui/system": "^9.0.0",
+        "@mui/types": "^9.0.0",
+        "@mui/utils": "^9.0.0",
         "@popperjs/core": "^2.11.8",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
         "csstype": "^3.2.3",
         "prop-types": "^15.8.1",
-        "react-is": "^19.2.3",
+        "react-is": "^19.2.4",
         "react-transition-group": "^4.4.5"
       },
       "engines": {
@@ -1305,7 +1305,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^7.3.9",
+        "@mui/material-pigment-css": "^9.0.0",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -1326,13 +1326,13 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.9.tgz",
-      "integrity": "sha512-ErIyRQvsiQEq7Yvcvfw9UDHngaqjMy9P3JDPnRAaKG5qhpl2C4tX/W1S4zJvpu+feihmZJStjIyvnv6KDbIrlw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-9.0.0.tgz",
+      "integrity": "sha512-JtuZoaiCqwD6vjgYu6Xp3T7DZkrxJlgtDz5yESzhI34fEX5hHMh2VJUbuL9UOg8xrfIFMrq6dcYoH/7Zi4G0RA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/utils": "^7.3.9",
+        "@babel/runtime": "^7.29.2",
+        "@mui/utils": "^9.0.0",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -1353,12 +1353,12 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.9.tgz",
-      "integrity": "sha512-JqujWt5bX4okjUPGpVof/7pvgClqh7HvIbsIBIOOlCh2u3wG/Bwp4+E1bc1dXSwkrkp9WUAoNdI5HEC+5HKvMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-9.0.0.tgz",
+      "integrity": "sha512-9RLGdX4Jg0aQPRuvqh/OLzYSPlgd5zyEw5/1HIRfdavSiOd03WtUaGZH9/w1RoTYuRKwpgy0hpIFaMHIqPVIWg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
+        "@babel/runtime": "^7.29.2",
         "@emotion/cache": "^11.14.0",
         "@emotion/serialize": "^1.3.3",
         "@emotion/sheet": "^1.4.0",
@@ -1387,16 +1387,16 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.9.tgz",
-      "integrity": "sha512-aL1q9am8XpRrSabv9qWf5RHhJICJql34wnrc1nz0MuOglPRYF/liN+c8VqZdTvUn9qg+ZjRVbKf4sJVFfIDtmg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.0.0.tgz",
+      "integrity": "sha512-YnC5Zg6j04IxiLc/boAKs0464jfZlLFVa7mf5E8lF0XOtZVUvG6R6gJK50lgUYdaaLdyLfxF6xR7LaPuEpeT/g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/private-theming": "^7.3.9",
-        "@mui/styled-engine": "^7.3.9",
-        "@mui/types": "^7.4.12",
-        "@mui/utils": "^7.3.9",
+        "@babel/runtime": "^7.29.2",
+        "@mui/private-theming": "^9.0.0",
+        "@mui/styled-engine": "^9.0.0",
+        "@mui/types": "^9.0.0",
+        "@mui/utils": "^9.0.0",
         "clsx": "^2.1.1",
         "csstype": "^3.2.3",
         "prop-types": "^15.8.1"
@@ -1427,12 +1427,12 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.4.12",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.12.tgz",
-      "integrity": "sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.0.0.tgz",
+      "integrity": "sha512-i1cuFCAWN44b3AJWO7mh7tuh1sqbQSeVr/94oG0TX5uXivac8XalgE4/6fQZcmGZigzbQ35IXxj/4jLpRIBYZg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6"
+        "@babel/runtime": "^7.29.2"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -1444,17 +1444,17 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.9.tgz",
-      "integrity": "sha512-U6SdZaGbfb65fqTsH3V5oJdFj9uYwyLE2WVuNvmbggTSDBb8QHrFsqY8BN3taK9t3yJ8/BPHD/kNvLNyjwM7Yw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.0.0.tgz",
+      "integrity": "sha512-bQcqyg/gjULUqTuyUjSAFr6LQGLvtkNtDbJerAtoUn9kGZ0hg5QJiN1PLHMLbeFpe3te1831uq7GFl2ITokGdg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/types": "^7.4.12",
+        "@babel/runtime": "^7.29.2",
+        "@mui/types": "^9.0.0",
         "@types/prop-types": "^15.7.15",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "react-is": "^19.2.3"
+        "react-is": "^19.2.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1474,16 +1474,16 @@
       }
     },
     "node_modules/@mui/x-charts": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-charts/-/x-charts-8.28.0.tgz",
-      "integrity": "sha512-KAVBjM/nT90rJ6IxslT8ko4BD9gQ4g3Fgk6+eRwEOROldEHhVBw4jUGgm9D9rJEo2bkCMbkX+hImP6aWH3w23g==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@mui/x-charts/-/x-charts-9.0.1.tgz",
+      "integrity": "sha512-0LyhlGhUm07wGJY0d0U+hSljGS1EHKWgPBsTJ/lBNGDrNc4DI9zSbp4h802LN/eLwMUVXJSI7DH2W3Ef3WsqnQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@mui/utils": "^7.3.5",
-        "@mui/x-charts-vendor": "8.26.0",
-        "@mui/x-internal-gestures": "0.4.0",
-        "@mui/x-internals": "8.26.0",
+        "@babel/runtime": "^7.28.6",
+        "@mui/utils": "9.0.0",
+        "@mui/x-charts-vendor": "^9.0.0",
+        "@mui/x-internal-gestures": "^9.0.0",
+        "@mui/x-internals": "^9.0.0",
         "bezier-easing": "^2.1.0",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
@@ -1496,8 +1496,8 @@
       "peerDependencies": {
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
-        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
-        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "@mui/material": "^7.3.0 || ^9.0.0",
+        "@mui/system": "^7.3.0 || ^9.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -1511,25 +1511,25 @@
       }
     },
     "node_modules/@mui/x-charts-vendor": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-charts-vendor/-/x-charts-vendor-8.26.0.tgz",
-      "integrity": "sha512-R//+WSWvsLJRTjTRN90EKX9sgRzAb4HQBvtUA3cTQpkGrmEjmatD4BJAm3IdRdkSagf6yKWF+ypESctyRhbwnA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-charts-vendor/-/x-charts-vendor-9.0.0.tgz",
+      "integrity": "sha512-Do91i+fZiNj/4LN5oaGpJoutolzDBDwdfw6tHrx2LKXDMCRlaImCfreLbdbkk7dFsi9fuIP7hWiMV4vDJKPJTA==",
       "license": "MIT AND ISC",
       "dependencies": {
-        "@babel/runtime": "^7.28.4",
+        "@babel/runtime": "^7.28.6",
         "@types/d3-array": "^3.2.2",
         "@types/d3-color": "^3.1.3",
         "@types/d3-format": "^3.0.4",
         "@types/d3-interpolate": "^3.0.4",
         "@types/d3-path": "^3.1.1",
         "@types/d3-scale": "^4.0.9",
-        "@types/d3-shape": "^3.1.7",
+        "@types/d3-shape": "^3.1.8",
         "@types/d3-time": "^3.0.4",
         "@types/d3-time-format": "^4.0.3",
         "@types/d3-timer": "^3.0.2",
         "d3-array": "^3.2.4",
         "d3-color": "^3.1.0",
-        "d3-format": "^3.1.0",
+        "d3-format": "^3.1.2",
         "d3-interpolate": "^3.0.1",
         "d3-path": "^3.1.0",
         "d3-scale": "^4.0.2",
@@ -1542,22 +1542,22 @@
       }
     },
     "node_modules/@mui/x-internal-gestures": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-internal-gestures/-/x-internal-gestures-0.4.0.tgz",
-      "integrity": "sha512-i0W6v9LoiNY8Yf1goOmaygtz/ncPJGBedhpDfvNg/i8BvzPwJcBaeW4rqPucJfVag9KQ8MSssBBrvYeEnrQmhw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internal-gestures/-/x-internal-gestures-9.0.0.tgz",
+      "integrity": "sha512-+fW1EUai25GJbivGRsi3GX4GYsSvzFPvUEjmMgB4POkRBDjrEZNaLdVWfapT6DlWv/Vfbi08bYSuyvhPXGMZjw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4"
+        "@babel/runtime": "^7.28.6"
       }
     },
     "node_modules/@mui/x-internals": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-8.26.0.tgz",
-      "integrity": "sha512-B9OZau5IQUvIxwpJZhoFJKqRpmWf5r0yMmSXjQuqb5WuqM755EuzWJOenY48denGoENzMLT8hQpA0hRTeU2IPA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-9.0.0.tgz",
+      "integrity": "sha512-E/4rdg69JjhyybpPGypCjAKSKLLnSdCFM+O6P/nkUg47+qt3uftxQEhjQO53rcn6ahHl6du/uNZ9BLgeY6kYxQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@mui/utils": "^7.3.5",
+        "@babel/runtime": "^7.28.6",
+        "@mui/utils": "9.0.0",
         "reselect": "^5.1.1",
         "use-sync-external-store": "^1.6.0"
       },

--- a/ui/package.json
+++ b/ui/package.json
@@ -36,8 +36,8 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
-    "@mui/material": "^7.3.9",
-    "@mui/x-charts": "^8.28.0",
+    "@mui/material": "^9.0.0",
+    "@mui/x-charts": "^9.0.1",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "zod": "^4.3.6"


### PR DESCRIPTION
# Description

This PR updates the MUI dependencies in the `ui/` directory to their latest versions and fixes the resulting breaking changes.

## Changes

- **ui/package.json**:
  - Updated `@mui/material` from `^7.3.9` to `^9.0.0`.
  - Updated `@mui/x-charts` from `^8.28.0` to `^9.0.1`.
- **ui/apps/dropdown/src/App.tsx**:
  - Updated `MenuProps` to use `slotProps.paper` instead of `PaperProps` to align with MUI v9 API.
- **ui/apps/timeserieschart/src/App.tsx**:
  - Replaced `textAlign="center"` on `Typography` with `sx={{ textAlign: 'center' }}` as `textAlign` is no longer a direct prop in this version.

## Rationale

Keeping dependencies up to date is important for security, performance, and accessing new features. This update brings the UI components to the latest major version of MUI.

## Verification Results

- **Tests**: Ran `npm test` in `ui/` and all tests passed.
- **Build**: Ran `npm run build` in `ui/` and both apps built successfully.
- **Presubmit**: Ran `./dev/tasks/presubmit.sh` and it passed successfully.
