### PR TITLE
chore: Bump version to 0.11.0

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -7,5 +7,5 @@
     }
   },
   "name": "gke-mcp",
-  "version": "0.10.0"
+  "version": "0.11.0"
 }


### PR DESCRIPTION
# chore: Bump version to 0.11.0

This PR bumps the version of the GKE MCP extension to 0.11.0.

### Motivation
To advance the version in `gemini-extension.json` from `0.10.0` to `0.11.0`, likely in preparation for a new release or to track development progress.

### Alternative Approaches
None considered. A direct version bump in the manifest is the standard procedure.

### Additional Context
No complex logic is changed, only the version identifier.
