### PR TITLE
fix(release): use go-version-file and bump version to 0.11.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,8 @@ jobs:
         with:
           go-version-file: "go.mod"
 
+      - uses: ./.github/actions/build-ui
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          check-latest: true
+          go-version-file: "go.mod"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -7,5 +7,5 @@
     }
   },
   "name": "gke-mcp",
-  "version": "0.11.0"
+  "version": "0.11.1"
 }


### PR DESCRIPTION
## 🎯 Why This Change?

This change ensures the Go version used in the release workflow matches the version specified in the project's `go.mod` file, improving consistency and reducing risks of version mismatch. It also bumps the extension version to `0.11.1`.

## 📝 What Changed?

**File:** `.github/workflows/release.yaml`

**Change:** Updated `setup-go` action to use `go-version-file: "go.mod"` instead of `check-latest: true`.

**File:** `gemini-extension.json`

**Change:** Bumped version from `0.11.0` to `0.11.1`.

## ✅ Why This Matters

Using `go-version-file` ensures that the CI/CD pipeline always uses the Go version intended for the project, as defined in the source of truth (`go.mod`). This avoids issues where a newer Go version might introduce incompatibilities or unexpected behavior during release.

## 🔗 Context

This is a minor update to the release workflow and a patch version bump.

## ✅ Testing

TESTED=https://github.com/bradhoekstra/gke-mcp/actions/runs/24512696252
