### PR TITLE
Abstract backend vertex pool and decouple agent mocks

### DIFF
--- a/pkg/agents/manifestgen/manifestgen.go
+++ b/pkg/agents/manifestgen/manifestgen.go
@@ -39,14 +39,11 @@ type Agent struct {
 	model GenerativeModel
 }
 
-// NewAgent creates a new Agent attached to the centralized vertex pool.
-func NewAgent(_ context.Context, c *vertex.Client) (*Agent, error) {
-	if c == nil {
-		return nil, fmt.Errorf("vertex connection provider cannot be nil")
+// NewAgent creates a new Agent attached to a specific text generator model.
+func NewAgent(model GenerativeModel) (*Agent, error) {
+	if model == nil {
+		return nil, fmt.Errorf("model cannot be nil")
 	}
-
-	// Retrieve optimized flash text template model
-	model := c.Model("gemini-2.5-flash")
 
 	return &Agent{model: model}, nil
 }
@@ -81,7 +78,8 @@ func Install(ctx context.Context, s *mcp.Server, c *config.Config) error {
 		return fmt.Errorf("failed initializing backend connection pool: %w", err)
 	}
 
-	agent, err := NewAgent(ctx, vClient)
+	model := vClient.Model("gemini-2.5-flash")
+	agent, err := NewAgent(model)
 	if err != nil {
 		return err
 	}

--- a/pkg/agents/manifestgen/manifestgen.go
+++ b/pkg/agents/manifestgen/manifestgen.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/vertexai/genai"
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/backend/vertex"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -28,36 +29,26 @@ import (
 //go:embed instruction.md
 var instructionTemplate string
 
-// Agent handles manifest generation using Vertex AI.
-type Agent struct {
-	client *genai.Client
-	model  *genai.GenerativeModel
+// GenerativeModel interface defines mockable text generation capabilities.
+type GenerativeModel interface {
+	GenerateContent(ctx context.Context, parts ...genai.Part) (*genai.GenerateContentResponse, error)
 }
 
-// NewAgent creates a new Agent.
-func NewAgent(ctx context.Context, cfg *config.Config) (*Agent, error) {
-	projectID := cfg.DefaultProjectID()
-	if projectID == "" {
-		return nil, fmt.Errorf("default project ID not set in config")
-	}
-	location := cfg.DefaultLocation()
-	if location == "" {
-		location = "us-central1" // Default fallback
-	}
+// Agent handles manifest generation via injected connection backend.
+type Agent struct {
+	model GenerativeModel
+}
 
-	client, err := genai.NewClient(ctx, projectID, location)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create vertex client: %w", err)
+// NewAgent creates a new Agent attached to the centralized vertex pool.
+func NewAgent(_ context.Context, c *vertex.Client) (*Agent, error) {
+	if c == nil {
+		return nil, fmt.Errorf("vertex connection provider cannot be nil")
 	}
 
-	// Use a default model, e.g., gemini-2.5-flash
-	// Note: gemini-2.5-pro might timeout on the massive set of instructions
-	model := client.GenerativeModel("gemini-2.5-flash")
+	// Retrieve optimized flash text template model
+	model := c.Model("gemini-2.5-flash")
 
-	return &Agent{
-		client: client,
-		model:  model,
-	}, nil
+	return &Agent{model: model}, nil
 }
 
 // GenerateManifest generates a Kubernetes manifest based on the prompt.
@@ -85,7 +76,12 @@ func (a *Agent) GenerateManifest(ctx context.Context, prompt string) (string, er
 
 // Install registers the tool with the MCP server.
 func Install(ctx context.Context, s *mcp.Server, c *config.Config) error {
-	agent, err := NewAgent(ctx, c)
+	vClient, err := vertex.New(ctx, c)
+	if err != nil {
+		return fmt.Errorf("failed initializing backend connection pool: %w", err)
+	}
+
+	agent, err := NewAgent(ctx, vClient)
 	if err != nil {
 		return err
 	}

--- a/pkg/agents/manifestgen/manifestgen_test.go
+++ b/pkg/agents/manifestgen/manifestgen_test.go
@@ -16,17 +16,53 @@ package manifestgen
 
 import (
 	"context"
+	"strings"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
+	"cloud.google.com/go/vertexai/genai"
 )
 
-func TestNewAgent_MissingProject(t *testing.T) {
-	ctx := context.Background()
-	cfg := &config.Config{} // Empty config
+type mockGenerativeModel struct {
+	res string
+	err error
+}
 
-	_, err := NewAgent(ctx, cfg)
+func (m *mockGenerativeModel) GenerateContent(_ context.Context, _ ...genai.Part) (*genai.GenerateContentResponse, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &genai.GenerateContentResponse{
+		Candidates: []*genai.Candidate{
+			{
+				Content: &genai.Content{
+					Parts: []genai.Part{
+						genai.Text(m.res),
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func TestNewAgent_NilClient(t *testing.T) {
+	ctx := context.Background()
+	_, err := NewAgent(ctx, nil)
 	if err == nil {
-		t.Errorf("Expected error for missing project, got nil")
+		t.Errorf("Expected error for nil connection module, got nil")
+	}
+}
+
+func TestGenerateManifest_Success(t *testing.T) {
+	agent := &Agent{
+		model: &mockGenerativeModel{res: "apiVersion: apps/v1\nkind: Deployment"},
+	}
+
+	manifest, err := agent.GenerateManifest(context.Background(), "nginx")
+	if err != nil {
+		t.Fatalf("GenerateManifest returned unexpected error: %v", err)
+	}
+
+	if !strings.Contains(manifest, "Deployment") {
+		t.Errorf("Expected simulated YAML response, got %v", manifest)
 	}
 }

--- a/pkg/agents/manifestgen/manifestgen_test.go
+++ b/pkg/agents/manifestgen/manifestgen_test.go
@@ -44,11 +44,10 @@ func (m *mockGenerativeModel) GenerateContent(_ context.Context, _ ...genai.Part
 	}, nil
 }
 
-func TestNewAgent_NilClient(t *testing.T) {
-	ctx := context.Background()
-	_, err := NewAgent(ctx, nil)
+func TestNewAgent_NilModel(t *testing.T) {
+	_, err := NewAgent(nil)
 	if err == nil {
-		t.Errorf("Expected error for nil connection module, got nil")
+		t.Errorf("Expected error for nil model, got nil")
 	}
 }
 

--- a/pkg/backend/vertex/vertex.go
+++ b/pkg/backend/vertex/vertex.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package vertex provides shared connections and models for agents.
+package vertex
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/vertexai/genai"
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
+)
+
+// Client manages a shared Vertex AI resource pool for all downstream agents.
+type Client struct {
+	underlying *genai.Client
+}
+
+// New initialized a singleton instance of the Google Cloud GenAI client.
+func New(ctx context.Context, cfg *config.Config) (*Client, error) {
+	projectID := cfg.DefaultProjectID()
+	if projectID == "" {
+		return nil, fmt.Errorf("projectID is required in shared connection config")
+	}
+
+	location := cfg.DefaultLocation()
+	if location == "" {
+		location = "us-central1"
+	}
+
+	client, err := genai.NewClient(ctx, projectID, location)
+	if err != nil {
+		return nil, fmt.Errorf("failed to establish top-level vertex AI pool: %w", err)
+	}
+
+	return &Client{underlying: client}, nil
+}
+
+// Model returns a shared or localized instance of a specific text generator.
+func (c *Client) Model(modelName string) *genai.GenerativeModel {
+	return c.underlying.GenerativeModel(modelName)
+}

--- a/pkg/backend/vertex/vertex.go
+++ b/pkg/backend/vertex/vertex.go
@@ -18,6 +18,7 @@ package vertex
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"cloud.google.com/go/vertexai/genai"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
@@ -28,8 +29,20 @@ type Client struct {
 	underlying *genai.Client
 }
 
+var (
+	mu       sync.Mutex
+	instance *Client
+)
+
 // New initialized a singleton instance of the Google Cloud GenAI client.
 func New(ctx context.Context, cfg *config.Config) (*Client, error) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if instance != nil {
+		return instance, nil
+	}
+
 	projectID := cfg.DefaultProjectID()
 	if projectID == "" {
 		return nil, fmt.Errorf("projectID is required in shared connection config")
@@ -45,7 +58,8 @@ func New(ctx context.Context, cfg *config.Config) (*Client, error) {
 		return nil, fmt.Errorf("failed to establish top-level vertex AI pool: %w", err)
 	}
 
-	return &Client{underlying: client}, nil
+	instance = &Client{underlying: client}
+	return instance, nil
 }
 
 // Model returns a shared or localized instance of a specific text generator.


### PR DESCRIPTION
This PR abstracts the Vertex AI backend into a centralized connection pool to support shared resource management across multiple agents. It also decouples the manifest generation logic from the concrete GenAI SDK by introducing a mockable interface, which enables more robust unit testing through dependency injection.

#250
