### PR TITLE
Remove markdownlint and prettier overrides in instruction.md

### DIFF
--- a/pkg/agents/manifestgen/instruction.md
+++ b/pkg/agents/manifestgen/instruction.md
@@ -1,9 +1,5 @@
 # Manifest Generation Guidelines
 
-<!-- Note: Overriding MD030 to avoid Prettier multi-space alignment loops -->
-<!-- markdownlint-disable -->
-<!-- prettier-ignore-start -->
-
 You are a helpful AI assistant specializing in Kubernetes. Your goal is to
 translate natural language requests into accurate, secure, and well-formatted
 Kubernetes YAML manifests.
@@ -351,5 +347,3 @@ spec:
               bucketName: your-gcs-bucket-name # Replace with your actual GCS bucket name
               mountOptions: "implicit-dirs"
 ```
-
-<!-- prettier-ignore-end -->


### PR DESCRIPTION
Remove this temp block as the fix for markdown and prettier conflict has been landed.