### PR TITLE
docs: fix pathing consistency in gke-workload-security skill

### DIFF
--- a/skills/gke-workload-security/SKILL.md
+++ b/skills/gke-workload-security/SKILL.md
@@ -67,7 +67,7 @@ access Google Cloud APIs.
    configuration. Update the `<ksa-name>` in the file first.
 
    ```bash
-   kubectl apply -f ./assets/workload-identity-pod.yaml
+   kubectl apply -f ./assets/workload-identity-pod.yaml -n workload-identity-test-ns
    ```
 
 ### 3. Implement Network Policies

--- a/skills/gke-workload-security/SKILL.md
+++ b/skills/gke-workload-security/SKILL.md
@@ -27,7 +27,7 @@ script.
 **Command:**
 
 ```bash
-./.agent/skills/gke-workload-security/scripts/audit_cluster.sh <cluster-name> <region> <project-id>
+./scripts/audit_cluster.sh <cluster-name> <region> <project-id>
 ```
 
 ### 2. Configure Workload Identity
@@ -67,7 +67,7 @@ access Google Cloud APIs.
    configuration. Update the `<ksa-name>` in the file first.
 
    ```bash
-   kubectl apply -f .agent/skills/gke-workload-security/assets/workload-identity-pod.yaml
+   kubectl apply -f ./assets/workload-identity-pod.yaml
    ```
 
 ### 3. Implement Network Policies
@@ -91,7 +91,9 @@ Isolate namespaces by denying all ingress and egress traffic by default.
 
 **Replace <target-namespace> with the namespace you want to isolate.**
 
-kubectl apply -f .agent/skills/gke-workload-security/assets/default-deny-netpol.yaml -n <target-namespace>
+```bash
+kubectl apply -f ./assets/default-deny-netpol.yaml -n <target-namespace>
+```
 
 ### 4. Enable Shielded Nodes
 


### PR DESCRIPTION
## 🎯 Why This Change?

This change fixes broken paths in the `gke-workload-security` skill. Previously, script and asset references used an internal `./.agent/skills/` path which was inconsistent with the repository structure, leading to execution failures when an agent attempted to use the skill.

## 📝 What Changed?

**File:** `skills/gke-workload-security/SKILL.md`

**Changes:** 
- Updated the path to the audit script from `./.agent/skills/gke-workload-security/scripts/audit_cluster.sh` to `./scripts/audit_cluster.sh`.
- Updated asset paths for Network Policy and Workload Identity manifests to be relative to the skill directory (`./assets/`).

## ✅ Why This Matters

Ensuring consistent and relative pathing allows the skills to be portable and functional across different environments and agent configurations. This fix ensures that the `audit_cluster.sh` script and related YAML assets are correctly located by the agent.

## 🔗 Context

Part of a general cleanup of pathing consistency in skills.

## ✅ Testing

Verified paths exist within the `skills/gke-workload-security/` directory.

TESTED=Local path verification.
