### PR TITLE
docs: add mandatory interactive dry run logic to GKE skills

### DIFF
--- a/skills/gke-app-onboarding/SKILL.md
+++ b/skills/gke-app-onboarding/SKILL.md
@@ -45,7 +45,14 @@ Generate Kubernetes manifests for the application:
   - Configure liveness and readiness probes.
 - **Service**: Create a Service manifest (e.g., ClusterIP for internal apps, LoadBalancer for external access). For advanced L7 routing, consider using the [Gateway API](../gke-networking-edge/SKILL.md).
 
-### 5. Initial Deployment
+### 5. Manifest Review (Dry Run)
+
+Before applying the manifests, review them with the user:
+
+- **Review**: Present the generated `Deployment`, `Service`, and any other manifests (YAML) to the user.
+- **Approval**: **MANDATORY**: Wait for explicit user approval before proceeding to deployment.
+
+### 6. Initial Deployment
 
 Apply the manifests and verify the deployment:
 

--- a/skills/gke-backup-dr/SKILL.md
+++ b/skills/gke-backup-dr/SKILL.md
@@ -9,6 +9,8 @@ This skill provides workflows for protecting your stateful workloads on GKE usin
 
 ## Workflows
 
+**MANDATORY**: Before enabling Backup for GKE, creating backup plans, or initiating restores, present the proposed command or manifest to the user and wait for explicit approval.
+
 ### 1. Enable Backup for GKE
 
 Backup for GKE must be enabled on the cluster level.

--- a/skills/gke-cluster-creator/SKILL.md
+++ b/skills/gke-cluster-creator/SKILL.md
@@ -16,9 +16,11 @@ This skill helps users create Google Kubernetes Engine (GKE) clusters by providi
    - Once a template is selected, present the default configuration (JSON/YAML).
    - Ask the user for essential missing information: `project_id`, `location`, `cluster_name`.
    - Ask if they want to modify optional fields (e.g., `machineType`, `nodeCount`, `network`).
-3. **Validation**:
+3. **Validation & Dry Run**:
    - Ensure `project_id`, `location`, and `cluster_name` are set.
    - Ensure the configuration matches the `create_cluster` MCP tool schema.
+   - **MANDATORY**: Present the final JSON configuration to the user.
+   - **MANDATORY**: Wait for explicit user approval before proceeding.
 4. **Execution**:
    - Call the `create_cluster` MCP tool with the final configuration.
 

--- a/skills/gke-cluster-lifecycle/SKILL.md
+++ b/skills/gke-cluster-lifecycle/SKILL.md
@@ -13,6 +13,8 @@ Managing cluster upgrades is crucial for security and access to new features. GK
 
 ## Workflows
 
+**MANDATORY**: Before updating release channels, modifying node pool surge settings, or implementing blue/green upgrades, present the proposed command or manifest to the user and wait for explicit approval.
+
 ### 1. Select Release Channels
 
 Release channels allow you to choose the balance between stability and feature availability.

--- a/skills/gke-compute-class-creator/SKILL.md
+++ b/skills/gke-compute-class-creator/SKILL.md
@@ -16,7 +16,9 @@ This skill helps you construct `ComputeClass` resources for Google Kubernetes En
    - **AI/ML**: Configure `gpu` or `tpu` fields.
 3. **Construct YAML**: Use the references below to build the `ComputeClass` manifest.
 4. **Validate**: Ensure all fields comply with the specification.
-5. **Apply**: Provide the user with the `kubectl apply -f <filename>.yaml` command.
+5. **Review & Apply**:
+   - **MANDATORY**: Present the final YAML manifest to the user.
+   - **MANDATORY**: Wait for explicit user approval before providing the `kubectl apply -f <filename>.yaml` command.
 
 ## References
 

--- a/skills/gke-cost-optimization/SKILL.md
+++ b/skills/gke-cost-optimization/SKILL.md
@@ -13,6 +13,8 @@ Cost optimization in GKE involves tracking costs, setting limits to prevent wast
 
 ## Workflows
 
+**MANDATORY**: Before running any `gcloud container clusters update` command to enable cost allocation or applying ResourceQuota manifests, present the proposed command or YAML to the user and wait for explicit approval.
+
 ### 1. Enable GKE Cost Allocation
 
 GKE cost allocation allows you to see the cost of your GKE resources in Cloud Billing, broken down by namespace and cluster labels.

--- a/skills/gke-inference-quickstart/SKILL.md
+++ b/skills/gke-inference-quickstart/SKILL.md
@@ -70,9 +70,9 @@ gcloud container ai profiles manifests create \
 ### 3. Review and Deploy
 
 1. **Save:** The example command above saves output to `inference-workload.yaml`. Ensure you have this file.
-2. **Review:** Check for any placeholders or specific requirements (like PVCs or secrets).
-   - _Note: Some models require Hugging Face tokens. Ensure query instructions for secrets are followed._
-3. **Deploy:**
+2. **Review:** **MANDATORY**: Present the contents of `inference-workload.yaml` to the user. Explain any requirements like PVCs, secrets, or Hugging Face tokens.
+3. **Approval**: **MANDATORY**: Wait for explicit user approval before proceeding to deployment.
+4. **Deploy**:
    ```bash
    kubectl apply -f inference-workload.yaml
    ```

--- a/skills/gke-multi-tenancy/SKILL.md
+++ b/skills/gke-multi-tenancy/SKILL.md
@@ -13,6 +13,8 @@ Multi-tenancy allows you to share a single GKE cluster among multiple teams or a
 
 ## Workflows
 
+**MANDATORY**: Before creating namespaces, applying RBAC roles, or enforcing resource quotas, present the proposed YAML manifests to the user and wait for explicit approval.
+
 ### 1. Create Namespaces for Isolation
 
 Namespaces provide a scope for names and are the primary unit of isolation in Kubernetes.

--- a/skills/gke-networking-edge/SKILL.md
+++ b/skills/gke-networking-edge/SKILL.md
@@ -9,6 +9,8 @@ This skill provides workflows for exposing applications running on GKE securely 
 
 ## Workflows
 
+**MANDATORY**: Before applying any networking configuration (Gateway, Ingress, BackendConfig, etc.), present the final YAML manifest to the user and wait for explicit approval.
+
 ### 1. Configure Gateway API (Recommended)
 
 The Gateway API is the modern way to manage routing in Kubernetes.

--- a/skills/gke-observability/SKILL.md
+++ b/skills/gke-observability/SKILL.md
@@ -9,6 +9,8 @@ This skill provides workflows for ensuring your GKE cluster and workloads have a
 
 ## Workflows
 
+**MANDATORY**: Before running any `gcloud container clusters update` command to enable observability features, present the command to the user and wait for explicit approval.
+
 ### 1. Audit Cluster Observability
 
 Check if Cloud Logging and Cloud Monitoring are enabled on the cluster.

--- a/skills/gke-reliability/SKILL.md
+++ b/skills/gke-reliability/SKILL.md
@@ -9,6 +9,8 @@ This skill provides workflows for configuring your GKE cluster and workloads for
 
 ## Workflows
 
+**MANDATORY**: Before applying PDBs, Topology Spread Constraints, or updating Maintenance Windows, present the final manifest or command to the user and wait for explicit approval.
+
 ### 1. Verify Cluster High Availability
 
 Check if the cluster is regional or has multi-zonal node pools.

--- a/skills/gke-storage/SKILL.md
+++ b/skills/gke-storage/SKILL.md
@@ -13,6 +13,8 @@ GKE supports various storage options, from Persistent Disks to Cloud Storage. Ch
 
 ## Workflows
 
+**MANDATORY**: Before creating StorageClasses or PersistentVolumeClaims, present the generated YAML manifest to the user and wait for explicit approval.
+
 ### 1. Configure Storage Classes
 
 StorageClasses allow you to describe the "classes" of storage you offer. Different classes might map to quality-of-service levels, or to backup policies.

--- a/skills/gke-workload-scaling/SKILL.md
+++ b/skills/gke-workload-scaling/SKILL.md
@@ -9,6 +9,8 @@ This skill provides workflows and best practices for scaling applications on Goo
 
 ## Workflows
 
+**MANDATORY**: Before scaling a deployment or enabling autoscaling (HPA/VPA/CA), present the proposed command or YAML manifest to the user and wait for explicit approval.
+
 ### 1. Manual Scaling
 
 Quickly scale a deployment to a fixed number of replicas. Useful for immediate manual intervention or testing.

--- a/skills/gke-workload-security/SKILL.md
+++ b/skills/gke-workload-security/SKILL.md
@@ -27,7 +27,7 @@ script.
 **Command:**
 
 ```bash
-./.agent/skills/gke-workload-security/scripts/audit_cluster.sh <cluster-name> <region> <project-id>
+./scripts/audit_cluster.sh <cluster-name> <region> <project-id>
 ```
 
 ### 2. Configure Workload Identity
@@ -67,7 +67,7 @@ access Google Cloud APIs.
    configuration. Update the `<ksa-name>` in the file first.
 
    ```bash
-   kubectl apply -f .agent/skills/gke-workload-security/assets/workload-identity-pod.yaml
+   kubectl apply -f ./assets/workload-identity-pod.yaml
    ```
 
 ### 3. Implement Network Policies
@@ -91,7 +91,9 @@ Isolate namespaces by denying all ingress and egress traffic by default.
 
 **Replace <target-namespace> with the namespace you want to isolate.**
 
-kubectl apply -f .agent/skills/gke-workload-security/assets/default-deny-netpol.yaml -n <target-namespace>
+```bash
+kubectl apply -f ./assets/default-deny-netpol.yaml -n <target-namespace>
+```
 
 ### 4. Enable Shielded Nodes
 

--- a/skills/gke-workload-security/SKILL.md
+++ b/skills/gke-workload-security/SKILL.md
@@ -75,6 +75,8 @@ access Google Cloud APIs.
 Control traffic flow between Pods using Network Policies. By default, all
 traffic is allowed.
 
+**MANDATORY**: Before applying policies or updating cluster addons, present the intended changes (commands or manifests) to the user and wait for explicit approval.
+
 **Enable Network Policy Enforcement:**
 
 ```bash
@@ -98,6 +100,8 @@ kubectl apply -f ./assets/default-deny-netpol.yaml -n <target-namespace>
 ### 4. Enable Shielded Nodes
 
 Ensure nodes are running with verifiable integrity.
+
+**MANDATORY**: Present the update command to the user and wait for explicit approval before proceeding.
 
 **Command:**
 


### PR DESCRIPTION
## 🎯 Why This Change?

This change improves the safety and user experience of GKE skills by enforcing a human-in-the-loop "Dry Run" pattern. It ensures that an agent will not execute state-changing operations (like creating clusters, modifying networking, or updating security settings) without first presenting the proposed configuration to the user for explicit approval.

## 📝 What Changed?

**Files:** Updated 14 skill files in `skills/` directory.

**Changes:** Added a "MANDATORY" instruction to the "Workflow" or "Instructions" section of each skill. This instruction requires the agent to:
1. Present the final YAML manifest or CLI command to the user.
2. Wait for explicit approval before proceeding with the execution.

Affected skills include:
- `gke-cluster-creator`
- `gke-app-onboarding`
- `gke-networking-edge`
- `gke-storage`
- `gke-workload-scaling`
- `gke-reliability`
- `gke-observability`
- `gke-inference-quickstart`
- `gke-cluster-lifecycle`
- `gke-backup-dr`
- `gke-compute-class-creator`
- `gke-multi-tenancy`
- `gke-cost-optimization`

## ✅ Why This Matters

AI agents can be highly efficient but occasionally unpredictable. By codifying a mandatory approval step in the skills themselves, we reduce the risk of accidental or unwanted infrastructure changes, ensuring that the human user remains the ultimate authority for state-changing GKE operations.

## 🔗 Context

This implements the "Interactive Dry Run Logic" improvement discussed during the repo analysis.

## ✅ Testing

Verified that the skill definitions now contain the mandatory instructions via manual inspection of the modified Markdown files.

TESTED=Local verification of skill file content.
