### PR TITLE
Decouple GIQ core logic from MCP transport

### DIFF
--- a/pkg/tools/giq/giq.go
+++ b/pkg/tools/giq/giq.go
@@ -25,7 +25,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-type giqGenerateManifestArgs struct {
+type GenerateInferenceManifestArgs struct {
 	Model                   string `json:"model" jsonschema:"The model to use. Get the list of valid models from 'gcloud container ai profiles models list' if the user doesn't provide it."`
 	ModelServer             string `json:"model_server" jsonschema:"The model server to use. Get the list of valid model servers from 'gcloud container ai profiles list --format='table(modelServerInfo.model,modelServerInfo.modelServer,modelServerInfo.modelServerVersion,acceleratorType)' if the user doesn't provide it. You can filter that gcloud command on '--model={model}' if the user provides the model."`
 	Accelerator             string `json:"accelerator" jsonschema:"The accelerator to use. Get the list of valid accelerators from 'gcloud container ai profiles list --format='table(modelServerInfo.model,modelServerInfo.modelServer,modelServerInfo.modelServerVersion,acceleratorType)' if the user doesn't provide it. You can filter that gcloud command on '--model={model}' and '--model-server={model-server}' if the user provides those values."`
@@ -47,7 +47,10 @@ func Install(_ context.Context, s *mcp.Server, _ *config.Config) error {
 }
 
 // GenerateInferenceManifest core logic for GKE Inference Quickstart manifest generation.
-func GenerateInferenceManifest(args *giqGenerateManifestArgs) (string, error) {
+func GenerateInferenceManifest(ctx context.Context, args *GenerateInferenceManifestArgs) (string, error) {
+	if args == nil {
+		return "", fmt.Errorf("args cannot be nil")
+	}
 	if args.Model == "" {
 		return "", fmt.Errorf("model argument cannot be empty")
 	}
@@ -72,7 +75,7 @@ func GenerateInferenceManifest(args *giqGenerateManifestArgs) (string, error) {
 		gcloudArgs = append(gcloudArgs, "--target-ntpot-milliseconds", args.TargetNTPOTMilliseconds)
 	}
 	// #nosec G204
-	out, err := exec.Command("gcloud", gcloudArgs...).Output()
+	out, err := exec.CommandContext(ctx, "gcloud", gcloudArgs...).Output()
 	if err != nil {
 		log.Printf("Failed to generate manifest: %v", err)
 		return "", err
@@ -80,8 +83,8 @@ func GenerateInferenceManifest(args *giqGenerateManifestArgs) (string, error) {
 	return string(out), nil
 }
 
-func giqGenerateManifest(_ context.Context, _ *mcp.CallToolRequest, args *giqGenerateManifestArgs) (*mcp.CallToolResult, any, error) {
-	manifest, err := GenerateInferenceManifest(args)
+func giqGenerateManifest(ctx context.Context, _ *mcp.CallToolRequest, args *GenerateInferenceManifestArgs) (*mcp.CallToolResult, any, error) {
+	manifest, err := GenerateInferenceManifest(ctx, args)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/tools/giq/giq.go
+++ b/pkg/tools/giq/giq.go
@@ -18,7 +18,6 @@ package giq
 import (
 	"context"
 	"fmt"
-	"log"
 	"os/exec"
 
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
@@ -77,8 +76,7 @@ func GenerateInferenceManifest(ctx context.Context, args *GenerateInferenceManif
 	// #nosec G204
 	out, err := exec.CommandContext(ctx, "gcloud", gcloudArgs...).Output()
 	if err != nil {
-		log.Printf("Failed to generate manifest: %v", err)
-		return "", err
+		return "", fmt.Errorf("failed to generate manifest: %w", err)
 	}
 	return string(out), nil
 }

--- a/pkg/tools/giq/giq.go
+++ b/pkg/tools/giq/giq.go
@@ -46,15 +46,16 @@ func Install(_ context.Context, s *mcp.Server, _ *config.Config) error {
 	return nil
 }
 
-func giqGenerateManifest(_ context.Context, _ *mcp.CallToolRequest, args *giqGenerateManifestArgs) (*mcp.CallToolResult, any, error) {
+// GenerateInferenceManifest core logic for GKE Inference Quickstart manifest generation.
+func GenerateInferenceManifest(args *giqGenerateManifestArgs) (string, error) {
 	if args.Model == "" {
-		return nil, nil, fmt.Errorf("model argument cannot be empty")
+		return "", fmt.Errorf("model argument cannot be empty")
 	}
 	if args.ModelServer == "" {
-		return nil, nil, fmt.Errorf("model_server argument cannot be empty")
+		return "", fmt.Errorf("model_server argument cannot be empty")
 	}
 	if args.Accelerator == "" {
-		return nil, nil, fmt.Errorf("accelerator argument cannot be empty")
+		return "", fmt.Errorf("accelerator argument cannot be empty")
 	}
 
 	gcloudArgs := []string{
@@ -74,12 +75,19 @@ func giqGenerateManifest(_ context.Context, _ *mcp.CallToolRequest, args *giqGen
 	out, err := exec.Command("gcloud", gcloudArgs...).Output()
 	if err != nil {
 		log.Printf("Failed to generate manifest: %v", err)
+		return "", err
+	}
+	return string(out), nil
+}
 
+func giqGenerateManifest(_ context.Context, _ *mcp.CallToolRequest, args *giqGenerateManifestArgs) (*mcp.CallToolResult, any, error) {
+	manifest, err := GenerateInferenceManifest(args)
+	if err != nil {
 		return nil, nil, err
 	}
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
-			&mcp.TextContent{Text: string(out)},
+			&mcp.TextContent{Text: manifest},
 		},
 	}, nil, nil
 }

--- a/pkg/tools/giq/giq.go
+++ b/pkg/tools/giq/giq.go
@@ -24,6 +24,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// GenerateInferenceManifestArgs holds arguments for generating a GKE Inference Quickstart manifest.
 type GenerateInferenceManifestArgs struct {
 	Model                   string `json:"model" jsonschema:"The model to use. Get the list of valid models from 'gcloud container ai profiles models list' if the user doesn't provide it."`
 	ModelServer             string `json:"model_server" jsonschema:"The model server to use. Get the list of valid model servers from 'gcloud container ai profiles list --format='table(modelServerInfo.model,modelServerInfo.modelServer,modelServerInfo.modelServerVersion,acceleratorType)' if the user doesn't provide it. You can filter that gcloud command on '--model={model}' if the user provides the model."`

--- a/pkg/tools/giq/giq_test.go
+++ b/pkg/tools/giq/giq_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestGiqGenerateManifestArgs_Fields(t *testing.T) {
-	args := giqGenerateManifestArgs{
+	args := GenerateInferenceManifestArgs{
 		Model:                   "llama-3-1-405b",
 		ModelServer:             "tgi",
 		Accelerator:             "nvidia-a100-80gb",
@@ -41,7 +41,7 @@ func TestGiqGenerateManifestArgs_Fields(t *testing.T) {
 }
 
 func TestGiqGenerateManifestArgs_RequiredFields(t *testing.T) {
-	args := giqGenerateManifestArgs{
+	args := GenerateInferenceManifestArgs{
 		Model:       "llama-3-1-8b",
 		ModelServer: "vllm",
 		Accelerator: "nvidia-l4",
@@ -62,7 +62,7 @@ func TestGiqGenerateManifestArgs_RequiredFields(t *testing.T) {
 }
 
 func TestGiqGenerateManifestArgs_Empty(t *testing.T) {
-	args := giqGenerateManifestArgs{}
+	args := GenerateInferenceManifestArgs{}
 	if args.Model != "" {
 		t.Errorf("Expected empty Model, got %s", args.Model)
 	}
@@ -78,7 +78,7 @@ func TestGiqGenerateManifestArgs_Empty(t *testing.T) {
 }
 
 func TestGiqGenerateManifestArgs_WithTargetNTPOT(t *testing.T) {
-	args := giqGenerateManifestArgs{
+	args := GenerateInferenceManifestArgs{
 		Model:                   "mixtral-8x7b",
 		ModelServer:             "tgi",
 		Accelerator:             "nvidia-a100-80gb",
@@ -103,7 +103,7 @@ func TestGiqGenerateManifestArgs_MultipleAccelerators(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args := giqGenerateManifestArgs{
+			args := GenerateInferenceManifestArgs{
 				Model:       "test-model",
 				ModelServer: "test-server",
 				Accelerator: tt.accelerator,
@@ -116,7 +116,7 @@ func TestGiqGenerateManifestArgs_MultipleAccelerators(t *testing.T) {
 }
 
 func TestGiqGenerateManifestArgs_JSONTags(t *testing.T) {
-	args := giqGenerateManifestArgs{
+	args := GenerateInferenceManifestArgs{
 		Model:       "test-model",
 		ModelServer: "test-server",
 		Accelerator: "test-accelerator",
@@ -130,7 +130,7 @@ func TestGiqGenerateManifestArgs_JSONTags(t *testing.T) {
 func TestGiqGenerateManifestArgs_DifferentModelServers(t *testing.T) {
 	servers := []string{"tgi", "vllm", "sglang"}
 	for _, server := range servers {
-		args := giqGenerateManifestArgs{
+		args := GenerateInferenceManifestArgs{
 			Model:       "test-model",
 			ModelServer: server,
 			Accelerator: "test-accelerator",


### PR DESCRIPTION
This PR refactors the GKE Inference Quickstart (GIQ) tool by decoupling the core manifest generation logic from the Model Context Protocol (MCP) transport layer. By extracting the underlying gcloud execution into a standalone GenerateInferenceManifest function, we improve code reusability and testability. This change ensures future compatibility, allowing the core logic to be integrated directly with ADK-managed agents or other internal components without relying on MCP-specific request structures.

Ref #330