### PR TITLE
Delete CODEOWNERS and fix presubmit

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,0 @@
-# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
-
-# Order is important; the last matching pattern takes the most precedence.
-
-# These owners will be the default owners for everything in the repo.
-*       @GoogleCloudPlatform/gke-mcp-owners
-


### PR DESCRIPTION
## Description
This PR deletes the `.github/CODEOWNERS` file as ownership is now managed by the Prow bot instead of the GitHub CODEOWNERS feature.

## Rationale
- Prow bot handles ownership, making `.github/CODEOWNERS` redundant and potentially conflicting.

## Test Results
- `./dev/tasks/presubmit.sh` passed locally after the fix.
