### PR TITLE
Remove redundant giq tool visibility to reduce agent hallucination 

### DIFF
--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -23,7 +23,6 @@ import (
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/cluster"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/clustertoolkit"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/deploy"
-
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/gkereleasenotes"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/k8schangelog"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/logging"

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -23,7 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/cluster"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/clustertoolkit"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/deploy"
-	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/giq"
+
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/gkereleasenotes"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/k8schangelog"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/logging"
@@ -40,7 +40,6 @@ func Install(ctx context.Context, s *mcp.Server, c *config.Config) error {
 		cluster.Install,
 		clustertoolkit.Install,
 		deploy.Install,
-		giq.Install,
 		logging.Install,
 		monitoring.Install,
 		recommendation.Install,


### PR DESCRIPTION
GIQ tool is exposed thru manifest generation agent instead. Removing redundant visibility to reduce agent hallucination. 

Ref #330