### PR TITLE
migrate from gcloud CLI to official gkerecommender Go SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.2
 
 require (
 	cloud.google.com/go/container v1.49.0
+	cloud.google.com/go/gkerecommender v0.4.0
 	cloud.google.com/go/logging v1.16.0
 	cloud.google.com/go/monitoring v1.27.0
 	cloud.google.com/go/recommender v1.16.0
@@ -26,7 +27,6 @@ require (
 	cloud.google.com/go/auth v0.20.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
-	cloud.google.com/go/gkerecommender v0.4.0 // indirect
 	cloud.google.com/go/iam v1.9.0 // indirect
 	cloud.google.com/go/longrunning v0.11.0 // indirect
 	github.com/andybalholm/cascadia v1.3.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	cloud.google.com/go/auth v0.20.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
+	cloud.google.com/go/gkerecommender v0.4.0 // indirect
 	cloud.google.com/go/iam v1.9.0 // indirect
 	cloud.google.com/go/longrunning v0.11.0 // indirect
 	github.com/andybalholm/cascadia v1.3.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 cloud.google.com/go/container v1.49.0 h1:K4nmtmJezHOzsIyedAOv1Ok36krw1apFmo4zXBaRL1A=
 cloud.google.com/go/container v1.49.0/go.mod h1:EvqoT2eXfxLweXXUlhAMGR0sOAB00XPzEjoL01esSDs=
+cloud.google.com/go/gkerecommender v0.4.0 h1:wd+d/KqLR3fyLvEXVLoUU8xumq568pxo885mBowxIas=
+cloud.google.com/go/gkerecommender v0.4.0/go.mod h1:mwWfMV0S9gYl0Y5gMa693RIuiYEisTJlK8EEF/nwihs=
 cloud.google.com/go/iam v1.9.0 h1:89wyjxT6DL4b5rk/Nk8eBC9DHqf+JiMstrn5IEYxFw4=
 cloud.google.com/go/iam v1.9.0/go.mod h1:KP+nKGugNJW4LcLx1uEZcq1ok5sQHFaQehQNl4QDgV4=
 cloud.google.com/go/logging v1.16.0 h1:MMNgYRvZ/pEwiNSkcoJTKWfAbAJDqCqAMJiarZx+/CI=

--- a/pkg/tools/giq/giq.go
+++ b/pkg/tools/giq/giq.go
@@ -84,13 +84,12 @@ func GenerateInferenceManifest(ctx context.Context, args *GenerateInferenceManif
 		return "", fmt.Errorf("failed to generate optimized manifest via SDK: %w", err)
 	}
 
-	var builder strings.Builder
+	var manifests []string
 	for _, m := range resp.GetKubernetesManifests() {
-		builder.WriteString(m.GetContent())
-		builder.WriteString("\n---\n")
+		manifests = append(manifests, m.GetContent())
 	}
 
-	return builder.String(), nil
+	return strings.Join(manifests, "\n---\n"), nil
 }
 
 func giqGenerateManifest(ctx context.Context, _ *mcp.CallToolRequest, args *GenerateInferenceManifestArgs) (*mcp.CallToolResult, any, error) {

--- a/pkg/tools/giq/giq.go
+++ b/pkg/tools/giq/giq.go
@@ -67,7 +67,9 @@ func GenerateInferenceManifest(ctx context.Context, args *GenerateInferenceManif
 	if err != nil {
 		return "", fmt.Errorf("failed to create gkerecommender client: %w", err)
 	}
-	defer client.Close()
+	defer func() {
+		_ = client.Close()
+	}()
 
 	req := &gkerecommenderpb.GenerateOptimizedManifestRequest{
 		ModelServerInfo: &gkerecommenderpb.ModelServerInfo{

--- a/pkg/tools/giq/giq.go
+++ b/pkg/tools/giq/giq.go
@@ -18,8 +18,10 @@ package giq
 import (
 	"context"
 	"fmt"
-	"os/exec"
+	"strings"
 
+	gkerecommender "cloud.google.com/go/gkerecommender/apiv1"
+	gkerecommenderpb "cloud.google.com/go/gkerecommender/apiv1/gkerecommenderpb"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -61,25 +63,32 @@ func GenerateInferenceManifest(ctx context.Context, args *GenerateInferenceManif
 		return "", fmt.Errorf("accelerator argument cannot be empty")
 	}
 
-	gcloudArgs := []string{
-		"container",
-		"ai",
-		"profiles",
-		"manifests",
-		"create",
-		"--model", args.Model,
-		"--model-server", args.ModelServer,
-		"--accelerator-type", args.Accelerator,
-	}
-	if args.TargetNTPOTMilliseconds != "" {
-		gcloudArgs = append(gcloudArgs, "--target-ntpot-milliseconds", args.TargetNTPOTMilliseconds)
-	}
-	// #nosec G204
-	out, err := exec.CommandContext(ctx, "gcloud", gcloudArgs...).Output()
+	client, err := gkerecommender.NewGkeInferenceQuickstartClient(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to generate manifest: %w", err)
+		return "", fmt.Errorf("failed to create gkerecommender client: %w", err)
 	}
-	return string(out), nil
+	defer client.Close()
+
+	req := &gkerecommenderpb.GenerateOptimizedManifestRequest{
+		ModelServerInfo: &gkerecommenderpb.ModelServerInfo{
+			Model:       args.Model,
+			ModelServer: args.ModelServer,
+		},
+		AcceleratorType: args.Accelerator,
+	}
+
+	resp, err := client.GenerateOptimizedManifest(ctx, req)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate optimized manifest via SDK: %w", err)
+	}
+
+	var builder strings.Builder
+	for _, m := range resp.GetKubernetesManifests() {
+		builder.WriteString(m.GetContent())
+		builder.WriteString("\n---\n")
+	}
+
+	return builder.String(), nil
 }
 
 func giqGenerateManifest(ctx context.Context, _ *mcp.CallToolRequest, args *GenerateInferenceManifestArgs) (*mcp.CallToolResult, any, error) {


### PR DESCRIPTION
Previously, the giq_generate_manifest tool relied on shelling out to the gcloud CLI (gcloud container ai profiles manifests create) to generate optimized inference manifests. This approach introduced several issues:

External Dependency: It forced OSS users to install and configure the gcloud CLI on their host machines.
Performance Overhead: Spawning external shell processes is significantly slower than direct API calls.
Fragile Parsing: It lacked strong type safety and structured data handling.

Solution: This PR refactors the GIQ tool to use the official public Go client (cloud.google.com/go/gkerecommender/apiv1)。 This aligns with our OSS adaptation strategy to remove internal/external CLI dependencies in favor of robust SDK integrations.

Ref #330