### PR TITLE
Update ownership and add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
+
+# Order is important; the last matching pattern takes the most precedence.
+
+# These owners will be the default owners for everything in the repo.
+*       @GoogleCloudPlatform/gke-mcp-approvers
+

--- a/OWNERS
+++ b/OWNERS
@@ -1,13 +1,13 @@
+# This list should be a superset of [gke-mcp-approvers](https://github.com/orgs/GoogleCloudPlatform/teams/gke-mcp-approvers).
 approvers:
 - adamparco
 - bradhoekstra
+- dshnayder
 - erain
 - GinnyJI
+- jayantid
 - juli4n
 - krzyzacy
-
-reviewers:
-- dshnayder
-- jayantid
 - stalhaali
 - toshiowang
+


### PR DESCRIPTION
# Update ownership and add CODEOWNERS

This PR updates the ownership configuration for the repository.

## Changes

*   **OWNERS**:
    *   Moved `dshnayder` and `jayantid` from `reviewers` to `approvers`.
    *   Removed the `reviewers` section as it was redundant or not needed.
    *   Added a comment pointing to the GitHub team for approvers.
*   **.github/CODEOWNERS**:
    *   Added this file to set `@GoogleCloudPlatform/gke-mcp-approvers` as the default owners for everything in the repository.

## Rationale

These changes ensure that the right people have approval authority and that all files have a default owner assigned, improving the review process and repository management.

## Verification

*   Ran `./dev/tasks/presubmit.sh` and all checks passed.
