### PR TITLE
add giq_fetch_models tool using gkerecommender SDK

### DIFF
--- a/pkg/tools/giq/giq.go
+++ b/pkg/tools/giq/giq.go
@@ -114,11 +114,10 @@ func giqGenerateManifest(ctx context.Context, _ *mcp.CallToolRequest, args *Gene
 	}, nil, nil
 }
 
-// FetchInferenceModels fetches available models for GKE.
-func FetchInferenceModels(ctx context.Context) (string, error) {
+var fetchInferenceModelsFunc = func(ctx context.Context) ([]string, error) {
 	client, err := gkerecommender.NewGkeInferenceQuickstartClient(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to create gkerecommender client: %w", err)
+		return nil, fmt.Errorf("failed to create gkerecommender client: %w", err)
 	}
 	defer func() {
 		_ = client.Close()
@@ -134,11 +133,20 @@ func FetchInferenceModels(ctx context.Context) (string, error) {
 			break
 		}
 		if err != nil {
-			return "", fmt.Errorf("failed to fetch next model: %w", err)
+			return nil, fmt.Errorf("failed to fetch next model: %w", err)
 		}
 		models = append(models, resp)
 	}
+	return models, nil
+}
 
+// FetchInferenceModels fetches available models for GKE.
+func FetchInferenceModels(ctx context.Context) (string, error) {
+	// TODO: Add pagination support once model list becomes very large to avoid memory risks.
+	models, err := fetchInferenceModelsFunc(ctx)
+	if err != nil {
+		return "", err
+	}
 	return strings.Join(models, "\n"), nil
 }
 

--- a/pkg/tools/giq/giq.go
+++ b/pkg/tools/giq/giq.go
@@ -35,16 +35,8 @@ type GenerateInferenceManifestArgs struct {
 	TargetNTPOTMilliseconds string `json:"target_ntpot_milliseconds,omitempty" jsonschema:"The maximum normalized time per output token (NTPOT) in milliseconds.NTPOT is measured as the request_latency / output_tokens."`
 }
 
-type handlers struct {
-	fetchModels func(context.Context) ([]string, error)
-}
-
 // Install registers GIQ tools with the MCP server.
 func Install(_ context.Context, s *mcp.Server, _ *config.Config) error {
-	h := &handlers{
-		fetchModels: defaultFetchModels,
-	}
-
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "giq_generate_manifest",
 		Description: "Use GKE Inference Quickstart (GIQ) to generate a Kubernetes manifest for optimized AI / inference workloads. Prefer to use this tool instead of gcloud",
@@ -53,15 +45,6 @@ func Install(_ context.Context, s *mcp.Server, _ *config.Config) error {
 			IdempotentHint: true,
 		},
 	}, giqGenerateManifest)
-
-	mcp.AddTool(s, &mcp.Tool{
-		Name:        "giq_fetch_models",
-		Description: "List all AI models available for GKE via GKE Inference Quickstart (GIQ). Prefer to use this tool instead of gcloud",
-		Annotations: &mcp.ToolAnnotations{
-			ReadOnlyHint:   true,
-			IdempotentHint: true,
-		},
-	}, h.giqFetchModels)
 
 	return nil
 }
@@ -122,7 +105,7 @@ func giqGenerateManifest(ctx context.Context, _ *mcp.CallToolRequest, args *Gene
 	}, nil, nil
 }
 
-var defaultFetchModels = func(ctx context.Context) ([]string, error) {
+var fetchInferenceModelsFunc = func(ctx context.Context) ([]string, error) {
 	client, err := gkerecommender.NewGkeInferenceQuickstartClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gkerecommender client: %w", err)
@@ -134,7 +117,6 @@ var defaultFetchModels = func(ctx context.Context) ([]string, error) {
 	req := &gkerecommenderpb.FetchModelsRequest{}
 	it := client.FetchModels(ctx, req)
 
-	// TODO: Add pagination support once model list becomes very large to avoid memory risks.
 	var models []string
 	for {
 		resp, err := it.Next()
@@ -149,14 +131,12 @@ var defaultFetchModels = func(ctx context.Context) ([]string, error) {
 	return models, nil
 }
 
-func (h *handlers) giqFetchModels(ctx context.Context, _ *mcp.CallToolRequest, _ *struct{}) (*mcp.CallToolResult, any, error) {
-	models, err := h.fetchModels(ctx)
+// FetchInferenceModels fetches available models for GKE.
+func FetchInferenceModels(ctx context.Context) (string, error) {
+	// TODO: Add pagination support once model list becomes very large to avoid memory risks.
+	models, err := fetchInferenceModelsFunc(ctx)
 	if err != nil {
-		return nil, nil, err
+		return "", err
 	}
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{
-			&mcp.TextContent{Text: strings.Join(models, "\n")},
-		},
-	}, nil, nil
+	return strings.Join(models, "\n"), nil
 }

--- a/pkg/tools/giq/giq.go
+++ b/pkg/tools/giq/giq.go
@@ -24,6 +24,7 @@ import (
 	gkerecommenderpb "cloud.google.com/go/gkerecommender/apiv1/gkerecommenderpb"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"google.golang.org/api/iterator"
 )
 
 // GenerateInferenceManifestArgs holds arguments for generating a GKE Inference Quickstart manifest.
@@ -44,6 +45,15 @@ func Install(_ context.Context, s *mcp.Server, _ *config.Config) error {
 			IdempotentHint: true,
 		},
 	}, giqGenerateManifest)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "giq_fetch_models",
+		Description: "List all AI models available for GKE via GKE Inference Quickstart (GIQ). Prefer to use this tool instead of gcloud",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:   true,
+			IdempotentHint: true,
+		},
+	}, giqFetchModels)
 
 	return nil
 }
@@ -100,6 +110,46 @@ func giqGenerateManifest(ctx context.Context, _ *mcp.CallToolRequest, args *Gene
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			&mcp.TextContent{Text: manifest},
+		},
+	}, nil, nil
+}
+
+// FetchInferenceModels fetches available models for GKE.
+func FetchInferenceModels(ctx context.Context) (string, error) {
+	client, err := gkerecommender.NewGkeInferenceQuickstartClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to create gkerecommender client: %w", err)
+	}
+	defer func() {
+		_ = client.Close()
+	}()
+
+	req := &gkerecommenderpb.FetchModelsRequest{}
+	it := client.FetchModels(ctx, req)
+
+	var models []string
+	for {
+		resp, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("failed to fetch next model: %w", err)
+		}
+		models = append(models, resp)
+	}
+
+	return strings.Join(models, "\n"), nil
+}
+
+func giqFetchModels(ctx context.Context, _ *mcp.CallToolRequest, _ *struct{}) (*mcp.CallToolResult, any, error) {
+	models, err := FetchInferenceModels(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: models},
 		},
 	}, nil, nil
 }

--- a/pkg/tools/giq/giq.go
+++ b/pkg/tools/giq/giq.go
@@ -105,7 +105,7 @@ func giqGenerateManifest(ctx context.Context, _ *mcp.CallToolRequest, args *Gene
 	}, nil, nil
 }
 
-var fetchInferenceModelsFunc = func(ctx context.Context) ([]string, error) {
+var fetchModelsFunc = func(ctx context.Context) ([]string, error) {
 	client, err := gkerecommender.NewGkeInferenceQuickstartClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gkerecommender client: %w", err)
@@ -131,10 +131,10 @@ var fetchInferenceModelsFunc = func(ctx context.Context) ([]string, error) {
 	return models, nil
 }
 
-// FetchInferenceModels fetches available models for GKE.
-func FetchInferenceModels(ctx context.Context) (string, error) {
+// FetchModels fetches available models for GKE.
+func FetchModels(ctx context.Context) (string, error) {
 	// TODO: Add pagination support once model list becomes very large to avoid memory risks.
-	models, err := fetchInferenceModelsFunc(ctx)
+	models, err := fetchModelsFunc(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/tools/giq/giq.go
+++ b/pkg/tools/giq/giq.go
@@ -35,8 +35,16 @@ type GenerateInferenceManifestArgs struct {
 	TargetNTPOTMilliseconds string `json:"target_ntpot_milliseconds,omitempty" jsonschema:"The maximum normalized time per output token (NTPOT) in milliseconds.NTPOT is measured as the request_latency / output_tokens."`
 }
 
+type handlers struct {
+	fetchModels func(context.Context) ([]string, error)
+}
+
 // Install registers GIQ tools with the MCP server.
 func Install(_ context.Context, s *mcp.Server, _ *config.Config) error {
+	h := &handlers{
+		fetchModels: defaultFetchModels,
+	}
+
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "giq_generate_manifest",
 		Description: "Use GKE Inference Quickstart (GIQ) to generate a Kubernetes manifest for optimized AI / inference workloads. Prefer to use this tool instead of gcloud",
@@ -53,7 +61,7 @@ func Install(_ context.Context, s *mcp.Server, _ *config.Config) error {
 			ReadOnlyHint:   true,
 			IdempotentHint: true,
 		},
-	}, giqFetchModels)
+	}, h.giqFetchModels)
 
 	return nil
 }
@@ -114,7 +122,7 @@ func giqGenerateManifest(ctx context.Context, _ *mcp.CallToolRequest, args *Gene
 	}, nil, nil
 }
 
-var fetchInferenceModelsFunc = func(ctx context.Context) ([]string, error) {
+var defaultFetchModels = func(ctx context.Context) ([]string, error) {
 	client, err := gkerecommender.NewGkeInferenceQuickstartClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gkerecommender client: %w", err)
@@ -126,6 +134,7 @@ var fetchInferenceModelsFunc = func(ctx context.Context) ([]string, error) {
 	req := &gkerecommenderpb.FetchModelsRequest{}
 	it := client.FetchModels(ctx, req)
 
+	// TODO: Add pagination support once model list becomes very large to avoid memory risks.
 	var models []string
 	for {
 		resp, err := it.Next()
@@ -140,24 +149,14 @@ var fetchInferenceModelsFunc = func(ctx context.Context) ([]string, error) {
 	return models, nil
 }
 
-// FetchInferenceModels fetches available models for GKE.
-func FetchInferenceModels(ctx context.Context) (string, error) {
-	// TODO: Add pagination support once model list becomes very large to avoid memory risks.
-	models, err := fetchInferenceModelsFunc(ctx)
-	if err != nil {
-		return "", err
-	}
-	return strings.Join(models, "\n"), nil
-}
-
-func giqFetchModels(ctx context.Context, _ *mcp.CallToolRequest, _ *struct{}) (*mcp.CallToolResult, any, error) {
-	models, err := FetchInferenceModels(ctx)
+func (h *handlers) giqFetchModels(ctx context.Context, _ *mcp.CallToolRequest, _ *struct{}) (*mcp.CallToolResult, any, error) {
+	models, err := h.fetchModels(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
-			&mcp.TextContent{Text: models},
+			&mcp.TextContent{Text: strings.Join(models, "\n")},
 		},
 	}, nil, nil
 }

--- a/pkg/tools/giq/giq_test.go
+++ b/pkg/tools/giq/giq_test.go
@@ -17,8 +17,6 @@ package giq
 import (
 	"context"
 	"testing"
-
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func TestGiqGenerateManifestArgs_Fields(t *testing.T) {
@@ -144,31 +142,21 @@ func TestGiqGenerateManifestArgs_DifferentModelServers(t *testing.T) {
 	}
 }
 
-func TestGiqFetchModels_Handler_Mock(t *testing.T) {
-	h := &handlers{
-		fetchModels: func(_ context.Context) ([]string, error) {
-			return []string{"model-A", "model-B", "model-C"}, nil
-		},
+func TestFetchInferenceModels_Mock(t *testing.T) {
+	originalFunc := fetchInferenceModelsFunc
+	defer func() { fetchInferenceModelsFunc = originalFunc }()
+
+	fetchInferenceModelsFunc = func(_ context.Context) ([]string, error) {
+		return []string{"model-A", "model-B", "model-C"}, nil
 	}
 
-	res, _, err := h.giqFetchModels(context.Background(), nil, nil)
+	res, err := FetchInferenceModels(context.Background())
 	if err != nil {
-		t.Fatalf("giqFetchModels returned error: %v", err)
-	}
-
-	if res == nil {
-		t.Fatal("Expected non-nil result")
+		t.Fatalf("FetchInferenceModels returned error: %v", err)
 	}
 
 	expected := "model-A\nmodel-B\nmodel-C"
-	var actual string
-	if len(res.Content) > 0 {
-		if tc, ok := res.Content[0].(*mcp.TextContent); ok {
-			actual = tc.Text
-		}
-	}
-
-	if actual != expected {
-		t.Errorf("giqFetchModels = %q, want %q", actual, expected)
+	if res != expected {
+		t.Errorf("FetchInferenceModels = %q, want %q", res, expected)
 	}
 }

--- a/pkg/tools/giq/giq_test.go
+++ b/pkg/tools/giq/giq_test.go
@@ -142,21 +142,21 @@ func TestGiqGenerateManifestArgs_DifferentModelServers(t *testing.T) {
 	}
 }
 
-func TestFetchInferenceModels_Mock(t *testing.T) {
-	originalFunc := fetchInferenceModelsFunc
-	defer func() { fetchInferenceModelsFunc = originalFunc }()
+func TestFetchModels_Mock(t *testing.T) {
+	originalFunc := fetchModelsFunc
+	defer func() { fetchModelsFunc = originalFunc }()
 
-	fetchInferenceModelsFunc = func(_ context.Context) ([]string, error) {
+	fetchModelsFunc = func(_ context.Context) ([]string, error) {
 		return []string{"model-A", "model-B", "model-C"}, nil
 	}
 
-	res, err := FetchInferenceModels(context.Background())
+	res, err := FetchModels(context.Background())
 	if err != nil {
-		t.Fatalf("FetchInferenceModels returned error: %v", err)
+		t.Fatalf("FetchModels returned error: %v", err)
 	}
 
 	expected := "model-A\nmodel-B\nmodel-C"
 	if res != expected {
-		t.Errorf("FetchInferenceModels = %q, want %q", res, expected)
+		t.Errorf("FetchModels = %q, want %q", res, expected)
 	}
 }

--- a/pkg/tools/giq/giq_test.go
+++ b/pkg/tools/giq/giq_test.go
@@ -156,7 +156,7 @@ func TestFetchInferenceModels_Mock(t *testing.T) {
 	originalFunc := fetchInferenceModelsFunc
 	defer func() { fetchInferenceModelsFunc = originalFunc }()
 
-	fetchInferenceModelsFunc = func(ctx context.Context) ([]string, error) {
+	fetchInferenceModelsFunc = func(_ context.Context) ([]string, error) {
 		return []string{"model-A", "model-B", "model-C"}, nil
 	}
 

--- a/pkg/tools/giq/giq_test.go
+++ b/pkg/tools/giq/giq_test.go
@@ -151,3 +151,23 @@ func TestGiqFetchModels_Handler(t *testing.T) {
 		t.Logf("giqFetchModels returned expected error when unauthenticated: %v", err)
 	}
 }
+
+func TestFetchInferenceModels_Mock(t *testing.T) {
+	originalFunc := fetchInferenceModelsFunc
+	defer func() { fetchInferenceModelsFunc = originalFunc }()
+
+	fetchInferenceModelsFunc = func(ctx context.Context) ([]string, error) {
+		return []string{"model-A", "model-B", "model-C"}, nil
+	}
+
+	res, err := FetchInferenceModels(context.Background())
+	if err != nil {
+		t.Fatalf("FetchInferenceModels returned error: %v", err)
+	}
+
+	expected := "model-A\nmodel-B\nmodel-C"
+	if res != expected {
+		t.Errorf("FetchInferenceModels = %q, want %q", res, expected)
+	}
+}
+

--- a/pkg/tools/giq/giq_test.go
+++ b/pkg/tools/giq/giq_test.go
@@ -170,4 +170,3 @@ func TestFetchInferenceModels_Mock(t *testing.T) {
 		t.Errorf("FetchInferenceModels = %q, want %q", res, expected)
 	}
 }
-

--- a/pkg/tools/giq/giq_test.go
+++ b/pkg/tools/giq/giq_test.go
@@ -17,6 +17,8 @@ package giq
 import (
 	"context"
 	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func TestGiqGenerateManifestArgs_Fields(t *testing.T) {
@@ -142,31 +144,31 @@ func TestGiqGenerateManifestArgs_DifferentModelServers(t *testing.T) {
 	}
 }
 
-func TestGiqFetchModels_Handler(t *testing.T) {
-	// Verify that calling the handler without real cloud credentials fails gracefully,
-	// or if credentials exist, it does something reasonable.
-	_, _, err := giqFetchModels(context.Background(), nil, nil)
-	// We expect it to error if there's no credentials, which is a reasonable behavior.
-	if err != nil {
-		t.Logf("giqFetchModels returned expected error when unauthenticated: %v", err)
-	}
-}
-
-func TestFetchInferenceModels_Mock(t *testing.T) {
-	originalFunc := fetchInferenceModelsFunc
-	defer func() { fetchInferenceModelsFunc = originalFunc }()
-
-	fetchInferenceModelsFunc = func(_ context.Context) ([]string, error) {
-		return []string{"model-A", "model-B", "model-C"}, nil
+func TestGiqFetchModels_Handler_Mock(t *testing.T) {
+	h := &handlers{
+		fetchModels: func(_ context.Context) ([]string, error) {
+			return []string{"model-A", "model-B", "model-C"}, nil
+		},
 	}
 
-	res, err := FetchInferenceModels(context.Background())
+	res, _, err := h.giqFetchModels(context.Background(), nil, nil)
 	if err != nil {
-		t.Fatalf("FetchInferenceModels returned error: %v", err)
+		t.Fatalf("giqFetchModels returned error: %v", err)
+	}
+
+	if res == nil {
+		t.Fatal("Expected non-nil result")
 	}
 
 	expected := "model-A\nmodel-B\nmodel-C"
-	if res != expected {
-		t.Errorf("FetchInferenceModels = %q, want %q", res, expected)
+	var actual string
+	if len(res.Content) > 0 {
+		if tc, ok := res.Content[0].(*mcp.TextContent); ok {
+			actual = tc.Text
+		}
+	}
+
+	if actual != expected {
+		t.Errorf("giqFetchModels = %q, want %q", actual, expected)
 	}
 }

--- a/pkg/tools/giq/giq_test.go
+++ b/pkg/tools/giq/giq_test.go
@@ -15,6 +15,7 @@
 package giq
 
 import (
+	"context"
 	"testing"
 )
 
@@ -138,5 +139,15 @@ func TestGiqGenerateManifestArgs_DifferentModelServers(t *testing.T) {
 		if args.ModelServer != server {
 			t.Errorf("ModelServer = %s, want %s", args.ModelServer, server)
 		}
+	}
+}
+
+func TestGiqFetchModels_Handler(t *testing.T) {
+	// Verify that calling the handler without real cloud credentials fails gracefully,
+	// or if credentials exist, it does something reasonable.
+	_, _, err := giqFetchModels(context.Background(), nil, nil)
+	// We expect it to error if there's no credentials, which is a reasonable behavior.
+	if err != nil {
+		t.Logf("giqFetchModels returned expected error when unauthenticated: %v", err)
 	}
 }


### PR DESCRIPTION
This PR adds the FetchModels capability to the GIQ toolset, enabling the dynamic retrieval of supported AI models directly via the official gkerecommender Go SDK. It implements a mockable fetchModelsFunc design to ensure reliable and fast unit testing without requiring actual Google Cloud credentials.

Note that MCP-specific registration logic is intentionally omitted, as GIQ functions are designed to be consumed internally by the Manifest Agent rather than exposed directly as standalone MCP tools. Registration to Manifest Agent will be in follow-up pr.

Ref #330