### PR TITLE
docs(skills): enforce workload identity and namespace isolation standards

### DIFF
--- a/skills/gke-app-onboarding/SKILL.md
+++ b/skills/gke-app-onboarding/SKILL.md
@@ -46,7 +46,7 @@ Generate Kubernetes manifests for the application:
 - **Deployment**: Create a `Deployment` manifest.
   - Include resource requests and limits.
   - Configure liveness and readiness probes.
-  - Reference the dedicated `ServiceAccount`.
+  - Reference the dedicated `ServiceAccount` using the `serviceAccountName` field.
 - **Service**: Create a Service manifest (e.g., ClusterIP for internal apps, LoadBalancer for external access). For advanced L7 routing, consider using the [Gateway API](../gke-networking-edge/SKILL.md).
 
 ### 5. Initial Deployment

--- a/skills/gke-app-onboarding/SKILL.md
+++ b/skills/gke-app-onboarding/SKILL.md
@@ -40,9 +40,13 @@ Build and store the container image:
 
 Generate Kubernetes manifests for the application:
 
+- **Namespace**: Create a dedicated `Namespace` for the application to isolate resources.
+  - **Security**: Label the namespace to enforce Pod Security Standards (e.g., `pod-security.kubernetes.io/enforce: restricted`).
+- **ServiceAccount**: Create a dedicated `ServiceAccount` for the application. Avoid using the `default` ServiceAccount to follow the principle of least privilege.
 - **Deployment**: Create a `Deployment` manifest.
   - Include resource requests and limits.
   - Configure liveness and readiness probes.
+  - Reference the dedicated `ServiceAccount`.
 - **Service**: Create a Service manifest (e.g., ClusterIP for internal apps, LoadBalancer for external access). For advanced L7 routing, consider using the [Gateway API](../gke-networking-edge/SKILL.md).
 
 ### 5. Initial Deployment

--- a/skills/gke-app-onboarding/SKILL.md
+++ b/skills/gke-app-onboarding/SKILL.md
@@ -41,7 +41,7 @@ Build and store the container image:
 Generate Kubernetes manifests for the application:
 
 - **Namespace**: Create a dedicated `Namespace` for the application to isolate resources.
-  - **Security**: Label the namespace to enforce Pod Security Standards (e.g., `pod-security.kubernetes.io/enforce: restricted`).
+  - **Security**: Label the namespace to enforce Pod Security Standards (e.g., `pod-security.kubernetes.io/enforce: restricted` and `pod-security.kubernetes.io/enforce-version: latest`).
 - **ServiceAccount**: Create a dedicated `ServiceAccount` for the application. Avoid using the `default` ServiceAccount to follow the principle of least privilege.
 - **Deployment**: Create a `Deployment` manifest.
   - Include resource requests and limits.

--- a/skills/gke-productionize/SKILL.md
+++ b/skills/gke-productionize/SKILL.md
@@ -37,6 +37,8 @@ Run these commands to understand the cluster setup:
 If a specific application is targeted, discover its configuration:
 
 - Get deployment/statefulset details: `kubectl get deployment <app-name> -n <namespace> -o yaml`
+- Check for dedicated namespace and labels: `kubectl get namespace <namespace> -o yaml` (Look for Pod Security Standards labels).
+- Check for dedicated service account: `kubectl get serviceaccount -n <namespace>`
 - Check for resource requests and limits.
 - Check for liveness, readiness, and startup probes.
 - Check for HPA: `kubectl get hpa -n <namespace>`
@@ -74,6 +76,8 @@ Ensure high availability and graceful degradation.
 Harden the cluster and workloads.
 
 - **Action**: You MUST activate [gke-workload-security](../gke-workload-security/SKILL.md) for Workload Identity, Network Policies, and Shielded Nodes.
+- **Namespace Isolation**: Ensure workloads run in dedicated namespaces with Pod Security Standards (PSS) enforced via labels.
+- **Least Privilege**: Ensure workloads use dedicated ServiceAccounts instead of the `default` ServiceAccount.
 
 #### F. Backup & Disaster Recovery
 

--- a/skills/gke-productionize/SKILL.md
+++ b/skills/gke-productionize/SKILL.md
@@ -38,7 +38,7 @@ If a specific application is targeted, discover its configuration:
 
 - Get deployment/statefulset details: `kubectl get deployment <app-name> -n <namespace> -o yaml`
 - Check for dedicated namespace and labels: `kubectl get namespace <namespace> -o yaml` (Look for Pod Security Standards labels).
-- Check for dedicated service account: `kubectl get serviceaccount -n <namespace>`
+- Check for dedicated service account usage: `kubectl get pods -n <namespace> -o jsonpath='{.items[*].spec.serviceAccountName}'`
 - Check for resource requests and limits.
 - Check for liveness, readiness, and startup probes.
 - Check for HPA: `kubectl get hpa -n <namespace>`

--- a/skills/gke-productionize/SKILL.md
+++ b/skills/gke-productionize/SKILL.md
@@ -38,7 +38,7 @@ If a specific application is targeted, discover its configuration:
 
 - Get deployment/statefulset details: `kubectl get deployment <app-name> -n <namespace> -o yaml`
 - Check for dedicated namespace and labels: `kubectl get namespace <namespace> -o yaml` (Look for Pod Security Standards labels).
-- Check for dedicated service account usage: `kubectl get pods -n <namespace> -o jsonpath='{.items[*].spec.serviceAccountName}'`
+- Check for dedicated service account usage: kubectl get pods -n <namespace> -o custom-columns="NAME:.metadata.name,SERVICE_ACCOUNT:.spec.serviceAccountName"
 - Check for resource requests and limits.
 - Check for liveness, readiness, and startup probes.
 - Check for HPA: `kubectl get hpa -n <namespace>`


### PR DESCRIPTION
## Description

This PR updates the GKE application onboarding and productionization skills to enforce best practices around namespace isolation, pod security, and the principle of least privilege. 

Specifically, the documentation now requires developers to:
- Use dedicated Namespaces for application isolation.
- Enforce Pod Security Standards (PSS) via namespace labels (e.g., `pod-security.kubernetes.io/enforce: restricted`).
- Use dedicated ServiceAccounts rather than the `default` account.
- Verify security configurations via `kubectl` commands during the production review phase.

## Rationale

Security boundaries in Kubernetes are critical for multi-tenant GKE clusters. 
By enforcing distinct namespaces and Workload Identity (via dedicated ServiceAccounts), we reduce the blast radius of compromised pods. Furthermore, explicitly documenting Pod Security Standards ensures that new applications adhere to restricted profiles, preventing the escalation of privileges.

## Verification

- [x] Ran `./dev/tasks/presubmit.sh` locally (Passes: UI tests, Go tests, Linter, and Format checks).
- [x] Verified updated markdown renders correctly.
