### PR TITLE
docs(skills): use local symlink references in gke-productionize

### DIFF
--- a/skills/gke-productionize/SKILL.md
+++ b/skills/gke-productionize/SKILL.md
@@ -49,49 +49,49 @@ If a specific application is targeted, discover its configuration:
 
 #### A. App Onboarding (Pre-Kubernetes)
 
-If the application is not yet running on GKE, delegate to the [gke-app-onboarding](../gke-app-onboarding/SKILL.md) skill for containerization and initial deployment.
+If the application is not yet running on GKE, delegate to the [gke-app-onboarding](references/gke-app-onboarding.md) skill for containerization and initial deployment.
 
 #### B. Scalability & Resource Management
 
 Ensure workloads have appropriate resources and autoscaling.
 
-- **Action**: You MUST activate [gke-workload-scaling](../gke-workload-scaling/SKILL.md) for configuring HPA, VPA, and resource limits.
+- **Action**: You MUST activate [gke-workload-scaling](references/gke-workload-scaling.md) for configuring HPA, VPA, and resource limits.
 
 #### C. Observability
 
 Ensure adequate logging and monitoring are in place.
 
-- **Action**: You MUST activate [gke-observability](../gke-observability/SKILL.md) for setting up Cloud Logging, Monitoring, and Managed Prometheus.
+- **Action**: You MUST activate [gke-observability](references/gke-observability.md) for setting up Cloud Logging, Monitoring, and Managed Prometheus.
 
 #### D. Reliability
 
 Ensure high availability and graceful degradation.
 
-- **Action**: You MUST activate [gke-reliability](../gke-reliability/SKILL.md) for configuring regional clusters, PDBs, and health probes.
+- **Action**: You MUST activate [gke-reliability](references/gke-reliability.md) for configuring regional clusters, PDBs, and health probes.
 
 #### E. Security
 
 Harden the cluster and workloads.
 
-- **Action**: You MUST activate [gke-workload-security](../gke-workload-security/SKILL.md) for Workload Identity, Network Policies, and Shielded Nodes.
+- **Action**: You MUST activate [gke-workload-security](references/gke-workload-security.md) for Workload Identity, Network Policies, and Shielded Nodes.
 
 #### F. Backup & Disaster Recovery
 
 Ensure stateful data is protected.
 
-- **Action**: You MUST activate [gke-backup-dr](../gke-backup-dr/SKILL.md) for configuring Backup for GKE and restore procedures.
+- **Action**: You MUST activate [gke-backup-dr](references/gke-backup-dr.md) for configuring Backup for GKE and restore procedures.
 
 #### G. Edge Security & Ingress
 
 Secure external access.
 
-- **Action**: You MUST activate [gke-networking-edge](../gke-networking-edge/SKILL.md) for Gateway API, Ingress, and Cloud Armor.
+- **Action**: You MUST activate [gke-networking-edge](references/gke-networking-edge.md) for Gateway API, Ingress, and Cloud Armor.
 
 #### H. Cost Optimization
 
 Ensure efficient use of resources.
 
-- **Action**: You MUST activate [gke-cost-optimization](../gke-cost-optimization/SKILL.md) for strategies on rightsizing, quotas, and Spot VMs.
+- **Action**: You MUST activate [gke-cost-optimization](references/gke-cost-optimization.md) for strategies on rightsizing, quotas, and Spot VMs.
 
 ### 3. Production Readiness Scoring
 

--- a/skills/gke-productionize/references/gke-app-onboarding.md
+++ b/skills/gke-productionize/references/gke-app-onboarding.md
@@ -1,0 +1,1 @@
+../../gke-app-onboarding/SKILL.md

--- a/skills/gke-productionize/references/gke-backup-dr.md
+++ b/skills/gke-productionize/references/gke-backup-dr.md
@@ -1,0 +1,1 @@
+../../gke-backup-dr/SKILL.md

--- a/skills/gke-productionize/references/gke-cost-optimization.md
+++ b/skills/gke-productionize/references/gke-cost-optimization.md
@@ -1,0 +1,1 @@
+../../gke-cost-optimization/SKILL.md

--- a/skills/gke-productionize/references/gke-networking-edge.md
+++ b/skills/gke-productionize/references/gke-networking-edge.md
@@ -1,0 +1,1 @@
+../../gke-networking-edge/SKILL.md

--- a/skills/gke-productionize/references/gke-observability.md
+++ b/skills/gke-productionize/references/gke-observability.md
@@ -1,0 +1,1 @@
+../../gke-observability/SKILL.md

--- a/skills/gke-productionize/references/gke-reliability.md
+++ b/skills/gke-productionize/references/gke-reliability.md
@@ -1,0 +1,1 @@
+../../gke-reliability/SKILL.md

--- a/skills/gke-productionize/references/gke-workload-scaling.md
+++ b/skills/gke-productionize/references/gke-workload-scaling.md
@@ -1,0 +1,1 @@
+../../gke-workload-scaling/SKILL.md

--- a/skills/gke-productionize/references/gke-workload-security.md
+++ b/skills/gke-productionize/references/gke-workload-security.md
@@ -1,0 +1,1 @@
+../../gke-workload-security/SKILL.md


### PR DESCRIPTION
## Description

This draft PR refactors the `gke-productionize` skill to use a localized `references/` directory for referencing other skills, rather than linking to their external paths.

This change improves the self-containment of the skill documentation. By establishing local symlinks (`references/$(SKILL_NAME).md -> ../../$(SKILL_NAME)/SKILL.md`), AI agents and developers can easily access related skill instructions without needing to parse deep relative paths.

## Proposed Changes
- Added `skills/gke-productionize/references/` containing symlinks for 8 associated skills (scaling, security, observability, etc.).
- Updated the markdown links in `skills/gke-productionize/SKILL.md` to point to these local references.

## Rationale
When a system relies on an orchestrator skill, providing immediate contextual file paths is easier for large language models and agents to index than navigating the file tree via `../`. Using symlinks achieves this without duplicating documentation content.

## Verification
- [x] Ran `./dev/tasks/presubmit.sh` locally (All checks passed).
- [x] Verified symlinks correctly resolve to their respective `SKILL.md` files.
- [x] Validated markdown link references.
