### PR TITLE
feat(config): generalized agent provider and model configuration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,7 @@ package config
 
 import (
 	"log"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -26,6 +27,8 @@ type Config struct {
 	userAgent        string
 	defaultProjectID string
 	defaultLocation  string
+	agentProvider    string
+	agentModel       string
 }
 
 // UserAgent returns the user agent string for outbound API calls.
@@ -43,12 +46,33 @@ func (c *Config) DefaultLocation() string {
 	return c.defaultLocation
 }
 
+// AgentProvider returns the configured LLM provider for the agent.
+func (c *Config) AgentProvider() string {
+	return c.agentProvider
+}
+
+// AgentModel returns the configured LLM model for the agent.
+func (c *Config) AgentModel() string {
+	return c.agentModel
+}
+
 // New constructs a Config populated from gcloud and build version.
 func New(version string) *Config {
+	provider := os.Getenv("GKE_MCP_PROVIDER")
+	if provider == "" {
+		provider = "vertex-ai"
+	}
+	model := os.Getenv("GKE_MCP_MODEL")
+	if model == "" {
+		model = "gemini-2.5-pro"
+	}
+
 	return &Config{
 		userAgent:        "gke-mcp/" + version,
 		defaultProjectID: getDefaultProjectID(),
 		defaultLocation:  getDefaultLocation(),
+		agentProvider:    provider,
+		agentModel:       model,
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -25,6 +25,27 @@ func TestNew(t *testing.T) {
 	if cfg.UserAgent() != "gke-mcp/"+version {
 		t.Errorf("UserAgent() = %s, want %s", cfg.UserAgent(), "gke-mcp/"+version)
 	}
+	if cfg.AgentProvider() != "vertex-ai" {
+		t.Errorf("AgentProvider() = %s, want vertex-ai", cfg.AgentProvider())
+	}
+	if cfg.AgentModel() != "gemini-2.5-pro" {
+		t.Errorf("AgentModel() = %s, want gemini-2.5-pro", cfg.AgentModel())
+	}
+}
+
+func TestNewWithEnvVars(t *testing.T) {
+	t.Setenv("GKE_MCP_PROVIDER", "custom-provider")
+	t.Setenv("GKE_MCP_MODEL", "custom-model")
+
+	version := "1.0.0"
+	cfg := New(version)
+
+	if cfg.AgentProvider() != "custom-provider" {
+		t.Errorf("AgentProvider() = %s, want custom-provider", cfg.AgentProvider())
+	}
+	if cfg.AgentModel() != "custom-model" {
+		t.Errorf("AgentModel() = %s, want custom-model", cfg.AgentModel())
+	}
 }
 
 func TestConfigGetters(t *testing.T) {


### PR DESCRIPTION
## Description
This PR introduces generalized configurations for the LLM provider and model, preparing the codebase for future subagents.

## Changes
- Added `agentProvider` and `agentModel` fields to `Config` struct.
- Generalized environment variables to `GKE_MCP_PROVIDER` and `GKE_MCP_MODEL`.
- Implemented corresponding getter methods.
- Added unit tests verifying the newly established configuration and environment variable behaviors.

## Validation
- Unit tests passed locally via `go test`.