### PR TITLE
refactor(giq): remove unused direct Install and giqGenerateManifest

### DIFF
--- a/pkg/tools/giq/giq.go
+++ b/pkg/tools/giq/giq.go
@@ -33,7 +33,6 @@ type GenerateInferenceManifestArgs struct {
 	TargetNTPOTMilliseconds string `json:"target_ntpot_milliseconds,omitempty" jsonschema:"The maximum normalized time per output token (NTPOT) in milliseconds.NTPOT is measured as the request_latency / output_tokens."`
 }
 
-
 // GenerateInferenceManifest core logic for GKE Inference Quickstart manifest generation.
 func GenerateInferenceManifest(ctx context.Context, args *GenerateInferenceManifestArgs) (string, error) {
 	if args == nil {

--- a/pkg/tools/giq/giq.go
+++ b/pkg/tools/giq/giq.go
@@ -22,8 +22,6 @@ import (
 
 	gkerecommender "cloud.google.com/go/gkerecommender/apiv1"
 	gkerecommenderpb "cloud.google.com/go/gkerecommender/apiv1/gkerecommenderpb"
-	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"google.golang.org/api/iterator"
 )
 
@@ -35,19 +33,6 @@ type GenerateInferenceManifestArgs struct {
 	TargetNTPOTMilliseconds string `json:"target_ntpot_milliseconds,omitempty" jsonschema:"The maximum normalized time per output token (NTPOT) in milliseconds.NTPOT is measured as the request_latency / output_tokens."`
 }
 
-// Install registers GIQ tools with the MCP server.
-func Install(_ context.Context, s *mcp.Server, _ *config.Config) error {
-	mcp.AddTool(s, &mcp.Tool{
-		Name:        "giq_generate_manifest",
-		Description: "Use GKE Inference Quickstart (GIQ) to generate a Kubernetes manifest for optimized AI / inference workloads. Prefer to use this tool instead of gcloud",
-		Annotations: &mcp.ToolAnnotations{
-			ReadOnlyHint:   true,
-			IdempotentHint: true,
-		},
-	}, giqGenerateManifest)
-
-	return nil
-}
 
 // GenerateInferenceManifest core logic for GKE Inference Quickstart manifest generation.
 func GenerateInferenceManifest(ctx context.Context, args *GenerateInferenceManifestArgs) (string, error) {
@@ -91,18 +76,6 @@ func GenerateInferenceManifest(ctx context.Context, args *GenerateInferenceManif
 	}
 
 	return strings.Join(manifests, "\n---\n"), nil
-}
-
-func giqGenerateManifest(ctx context.Context, _ *mcp.CallToolRequest, args *GenerateInferenceManifestArgs) (*mcp.CallToolResult, any, error) {
-	manifest, err := GenerateInferenceManifest(ctx, args)
-	if err != nil {
-		return nil, nil, err
-	}
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{
-			&mcp.TextContent{Text: manifest},
-		},
-	}, nil, nil
 }
 
 var fetchModelsFunc = func(ctx context.Context) ([]string, error) {


### PR DESCRIPTION
This aligns with our plan to deprecate the use of direct install of giq tool

Ref #330