### PR TITLE
feat(llm): implement abstract LLM factory

### DIFF
--- a/pkg/agents/manifestgen/manifestgen.go
+++ b/pkg/agents/manifestgen/manifestgen.go
@@ -24,13 +24,13 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/llm"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/giq"
 	"github.com/google/uuid"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/agent/llmagent"
 	"google.golang.org/adk/model"
-	"google.golang.org/adk/model/gemini"
 	"google.golang.org/adk/runner"
 	"google.golang.org/adk/session"
 	"google.golang.org/adk/tool"
@@ -40,8 +40,6 @@ import (
 
 //go:embed instruction.md
 var instructionTemplate string
-
-const defaultModel = "gemini-2.5-pro"
 
 // Agent handles manifest generation via ADK.
 type Agent struct {
@@ -196,17 +194,12 @@ func (a *Agent) Run(ctx context.Context, prompt string, sessionID string) (strin
 
 // Install registers the tool with the MCP server.
 func Install(ctx context.Context, s *mcp.Server, c *config.Config) error {
-	// Create a new Gemini model backed by Vertex AI via ADK
-	llm, err := gemini.NewModel(ctx, defaultModel, &genai.ClientConfig{
-		Project:  c.DefaultProjectID(),
-		Backend:  genai.BackendVertexAI,
-		Location: c.DefaultLocation(),
-	})
+	llmClient, err := llm.NewClient(ctx, c)
 	if err != nil {
-		return fmt.Errorf("failed to create gemini model: %w", err)
+		return fmt.Errorf("failed to create llm client: %w", err)
 	}
 
-	agent, err := NewAgent(llm, c)
+	agent, err := NewAgent(llmClient, c)
 	if err != nil {
 		return err
 	}
@@ -225,6 +218,9 @@ func Install(ctx context.Context, s *mcp.Server, c *config.Config) error {
 		manifest, err := agent.Run(ctx, args.Prompt, sessID)
 		if err != nil {
 			return nil, nil, err
+		}
+		if os.Getenv("GKE_MCP_DEBUG") == "true" {
+			log.Printf("Model Used: %s", c.AgentModel())
 		}
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -83,6 +83,18 @@ func New(version string, enableDeleteTools bool) *Config {
 	}
 }
 
+// NewTestConfig constructs a mock configuration for testing purposes.
+func NewTestConfig(project, location, provider, model string) *Config {
+	return &Config{
+		userAgent:         "gke-mcp/test",
+		defaultProjectID:  project,
+		defaultLocation:   location,
+		agentProvider:     provider,
+		agentModel:        model,
+		enableDeleteTools: false,
+	}
+}
+
 func getDefaultProjectID() string {
 	projectID, err := getGcloudConfig("core/project")
 	if err != nil {

--- a/pkg/llm/factory.go
+++ b/pkg/llm/factory.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package llm provides a factory for initializing vendor-agnostic LLM clients.
+package llm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/model/gemini"
+	"google.golang.org/genai"
+)
+
+// NewClient creates and returns a vendor-agnostic ADK LLM model based on configuration.
+func NewClient(ctx context.Context, cfg *config.Config) (model.LLM, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config parameter 'cfg' cannot be nil")
+	}
+
+	provider, err := parseProvider(cfg.AgentProvider())
+	if err != nil {
+		return nil, err
+	}
+
+	switch provider {
+	case "vertex-ai":
+		llm, err := gemini.NewModel(ctx, cfg.AgentModel(), &genai.ClientConfig{
+			Project:  cfg.DefaultProjectID(),
+			Backend:  genai.BackendVertexAI,
+			Location: cfg.DefaultLocation(),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize Vertex AI model: %w", err)
+		}
+		return llm, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported LLM provider: %s", cfg.AgentProvider())
+	}
+}
+
+func parseProvider(provider string) (string, error) {
+	p := strings.ToLower(strings.TrimSpace(provider))
+	switch p {
+	case "vertex-ai":
+		return "vertex-ai", nil
+	default:
+		return "", fmt.Errorf("unsupported LLM provider: %s", provider)
+	}
+}

--- a/pkg/llm/factory_test.go
+++ b/pkg/llm/factory_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
+)
+
+func TestNewClient_NilConfig(t *testing.T) {
+	_, err := NewClient(context.Background(), nil)
+
+	if err == nil {
+		t.Errorf("Expected error for nil config, got nil")
+	}
+}
+
+func TestNewClient_UnsupportedProvider(t *testing.T) {
+	cfg := config.NewTestConfig("test-project", "us-central1", "unsupported-provider", "gemini-2.5-pro")
+	_, err := NewClient(context.Background(), cfg)
+
+	if err == nil {
+		t.Errorf("Expected error for unsupported provider, got nil")
+	}
+}
+
+func TestParseProvider_CaseInsensitive(t *testing.T) {
+	provider, err := parseProvider("  VeRtEx-AI ")
+
+	if err != nil {
+		t.Errorf("Expected no error for mixed-case vertex provider, got %v", err)
+	}
+	if provider != "vertex-ai" {
+		t.Errorf("Expected vertex-ai, got %s", provider)
+	}
+}


### PR DESCRIPTION
## Description
This PR introduces the abstract LLM Factory (`pkg/llm/factory.go`) which dynamically initializes underlying vendor-agnostic LLM models based on configurations.

## Changes
- Implemented `NewClient(ctx context.Context, cfg *config.Config) (model.LLM, error)`.
- Supports `vertex-ai` as the default provider.
- Added isolation tests for unsupported providers.

## Validation
- Go unit tests (`go test ./...`) passed successfully.
- Differential DeepEval tests confirm that specialized instruction adherence remains intact when utilizing the abstract LLM Factory.