### PR TITLE
feat: add operations tools

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,10 +48,11 @@ var (
 	version = "(unknown)"
 
 	// command flags
-	serverMode     string
-	serverHost     string
-	serverPort     int
-	allowedOrigins []string
+	serverMode        string
+	serverHost        string
+	serverPort        int
+	allowedOrigins    []string
+	enableDeleteTools bool
 
 	// rootCmd represents the base command when called without any subcommands
 	rootCmd = &cobra.Command{
@@ -113,6 +114,7 @@ func init() {
 	rootCmd.Flags().StringVar(&serverHost, "server-host", "127.0.0.1", "server host to use when server-mode is http; defaults to 127.0.0.1")
 	rootCmd.Flags().IntVar(&serverPort, "server-port", 8080, "server port to use when server-mode is http; defaults to 8080")
 	rootCmd.Flags().StringSliceVar(&allowedOrigins, "allowed-origins", []string{"http://localhost"}, "comma-separated list of allowed Origin headers")
+	rootCmd.Flags().BoolVar(&enableDeleteTools, "enable-delete-tools", false, "Enable destructive delete tools (delete_cluster, delete_node_pool)")
 	rootCmd.AddCommand(installCmd)
 
 	installCmd.AddCommand(installGeminiCLICmd)
@@ -145,7 +147,7 @@ func runRootCmd(cmd *cobra.Command, _ []string) {
 }
 
 func startMCPServer(ctx context.Context, opts startOptions) {
-	c := config.New(version)
+	c := config.New(version, enableDeleteTools)
 
 	instructions := ""
 	if err := adcAuthCheck(ctx, c); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.12.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
+	github.com/googleapis/gax-go/v2 v2.22.0
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/rs/cors v1.11.1
 	github.com/spf13/cobra v1.10.2
@@ -40,7 +41,6 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/safehtml v0.1.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect
-	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,9 +23,10 @@ import (
 
 // Config contains runtime configuration derived from the environment.
 type Config struct {
-	userAgent        string
-	defaultProjectID string
-	defaultLocation  string
+	userAgent         string
+	defaultProjectID  string
+	defaultLocation   string
+	enableDeleteTools bool
 }
 
 // UserAgent returns the user agent string for outbound API calls.
@@ -43,12 +44,18 @@ func (c *Config) DefaultLocation() string {
 	return c.defaultLocation
 }
 
+// EnableDeleteTools returns true if destructive delete tools are enabled.
+func (c *Config) EnableDeleteTools() bool {
+	return c.enableDeleteTools
+}
+
 // New constructs a Config populated from gcloud and build version.
-func New(version string) *Config {
+func New(version string, enableDeleteTools bool) *Config {
 	return &Config{
-		userAgent:        "gke-mcp/" + version,
-		defaultProjectID: getDefaultProjectID(),
-		defaultLocation:  getDefaultLocation(),
+		userAgent:         "gke-mcp/" + version,
+		defaultProjectID:  getDefaultProjectID(),
+		defaultLocation:   getDefaultLocation(),
+		enableDeleteTools: enableDeleteTools,
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -20,18 +20,22 @@ import (
 
 func TestNew(t *testing.T) {
 	version := "1.0.0"
-	cfg := New(version)
+	cfg := New(version, false)
 
 	if cfg.UserAgent() != "gke-mcp/"+version {
 		t.Errorf("UserAgent() = %s, want %s", cfg.UserAgent(), "gke-mcp/"+version)
+	}
+	if cfg.EnableDeleteTools() {
+		t.Error("Expected EnableDeleteTools to be false")
 	}
 }
 
 func TestConfigGetters(t *testing.T) {
 	cfg := &Config{
-		userAgent:        "test-agent",
-		defaultProjectID: "test-project",
-		defaultLocation:  "us-central1",
+		userAgent:         "test-agent",
+		defaultProjectID:  "test-project",
+		defaultLocation:   "us-central1",
+		enableDeleteTools: true,
 	}
 
 	if got := cfg.UserAgent(); got != "test-agent" {
@@ -43,11 +47,14 @@ func TestConfigGetters(t *testing.T) {
 	if got := cfg.DefaultLocation(); got != "us-central1" {
 		t.Errorf("DefaultLocation() = %s, want us-central1", got)
 	}
+	if !cfg.EnableDeleteTools() {
+		t.Error("Expected EnableDeleteTools to be true")
+	}
 }
 
 func TestNewConfigWithVersion(t *testing.T) {
 	testVersion := "0.1.0"
-	cfg := New(testVersion)
+	cfg := New(testVersion, true)
 
 	if cfg == nil {
 		t.Fatal("New() returned nil")
@@ -57,13 +64,17 @@ func TestNewConfigWithVersion(t *testing.T) {
 	if cfg.UserAgent() != expectedUserAgent {
 		t.Errorf("UserAgent() = %s, want %s", cfg.UserAgent(), expectedUserAgent)
 	}
+	if !cfg.EnableDeleteTools() {
+		t.Error("Expected EnableDeleteTools to be true")
+	}
 }
 
 func TestConfigFields(t *testing.T) {
 	cfg := &Config{
-		userAgent:        "test-agent",
-		defaultProjectID: "my-project",
-		defaultLocation:  "us-west1",
+		userAgent:         "test-agent",
+		defaultProjectID:  "my-project",
+		defaultLocation:   "us-west1",
+		enableDeleteTools: false,
 	}
 
 	tests := []struct {
@@ -88,7 +99,7 @@ func TestConfigFields(t *testing.T) {
 func TestConfigUserAgentFormat(t *testing.T) {
 	versions := []string{"0.1.0", "1.0.0", "latest", "v1.2.3"}
 	for _, v := range versions {
-		cfg := New(v)
+		cfg := New(v, false)
 		expected := "gke-mcp/" + v
 		if got := cfg.UserAgent(); got != expected {
 			t.Errorf("UserAgent() for version %s = %s, want %s", v, got, expected)
@@ -162,7 +173,7 @@ func TestNewConfigDifferentVersions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.version, func(t *testing.T) {
-			cfg := New(tt.version)
+			cfg := New(tt.version, false)
 			if cfg.UserAgent() != tt.wantAgent {
 				t.Errorf("UserAgent() = %s, want %s", cfg.UserAgent(), tt.wantAgent)
 			}

--- a/pkg/tools/cluster/cluster.go
+++ b/pkg/tools/cluster/cluster.go
@@ -97,7 +97,7 @@ type getClustersArgs struct {
 }
 
 type createClustersArgs struct {
-	params.Location
+	params.LocationRequired
 	Cluster string `json:"cluster" jsonschema:"Required. A cluster resource represented as a string using JSON format."`
 }
 
@@ -215,7 +215,7 @@ func (h *handlers) getKubeconfig(ctx context.Context, _ *mcp.CallToolRequest, ar
 	}
 
 	// Standard naming convention for gcloud-generated kubeconfigs
-	newClusterName := fmt.Sprintf("gke_%s_%s_%s", args.ProjectID, args.Location.Location, args.ClusterName)
+	newClusterName := fmt.Sprintf("gke_%s_%s_%s", args.ProjectID, args.Location, args.ClusterName)
 
 	// Initialize a Kubeconfig object
 	pathOptions := clientcmd.NewDefaultPathOptions()
@@ -263,7 +263,7 @@ func (h *handlers) getKubeconfig(ctx context.Context, _ *mcp.CallToolRequest, ar
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
-			&mcp.TextContent{Text: fmt.Sprintf("Kubeconfig for cluster %s (Project: %s, Location: %s) successfully appended/updated in %s. Current context set to %s.", args.ClusterPath(), args.ProjectID, args.Location.Location, pathOptions.GlobalFile, newClusterName)},
+			&mcp.TextContent{Text: fmt.Sprintf("Kubeconfig for cluster %s (Project: %s, Location: %s) successfully appended/updated in %s. Current context set to %s.", args.ClusterPath(), args.ProjectID, args.Location, pathOptions.GlobalFile, newClusterName)},
 		},
 	}, nil, nil
 }

--- a/pkg/tools/cluster/cluster.go
+++ b/pkg/tools/cluster/cluster.go
@@ -88,12 +88,12 @@ type handlers struct {
 
 type listClustersArgs struct {
 	params.LocationOptional
-	ReadMask string `json:"readMask,omitempty" jsonschema:"Optional. The field mask to specify the fields to be returned in the response."`
+	ReadMask string `json:"readMask,omitempty" jsonschema:"Optional. The field mask to specify the fields to be returned in the response. Use a single * to get all fields. Default: clusters.autopilot,clusters.createTime,clusters.currentMasterVersion,clusters.currentNodeCount,clusters.currentNodeVersion,clusters.description,clusters.endpoint,clusters.fleet,clusters.location,clusters.name,clusters.network,clusters.nodePools.name,clusters.releaseChannel,clusters.resourceLabels,clusters.selfLink,clusters.status,clusters.statusMessage,clusters.subnetwork,missingZones."`
 }
 
 type getClustersArgs struct {
 	params.Cluster
-	ReadMask string `json:"readMask,omitempty" jsonschema:"Optional. The field mask to specify the fields to be returned in the response."`
+	ReadMask string `json:"readMask,omitempty" jsonschema:"Optional. The field mask to specify the fields to be returned in the response. Use a single * to get all fields. Default: autopilot,createTime,currentMasterVersion,currentNodeCount,currentNodeVersion,description,endpoint,fleet,location,name,network,nodePools.locations,nodePools.name,nodePools.status,nodePools.version,releaseChannel,resourceLabels,selfLink,status,statusMessage,subnetwork."`
 }
 
 type createClustersArgs struct {
@@ -117,7 +117,7 @@ type getKubeconfigArgs struct {
 
 type getNodeSosReportArgs struct {
 	params.Cluster
-	Node           string `json:"node" jsonschema:"GKE node name to collect SOS report from."`
+	Node           string `json:"node" jsonschema:"Required. GKE node name to collect SOS report from."`
 	Destination    string `json:"destination,omitempty" jsonschema:"Local directory to download the SOS report to. Defaults to /tmp/sos-report if not specified."`
 	Method         string `json:"method,omitempty" jsonschema:"Method to get sos report. Can be 'pod', 'ssh' or 'any'. Defaults to 'any'. When the node is unhealthy from api server, use ssh only."`
 	TimeoutSeconds int    `json:"timeout,omitempty" jsonschema:"Timeout in seconds for the report collection (applies to both pod and ssh methods). Defaults to 180 (3 minutes)."`
@@ -215,7 +215,7 @@ func (h *handlers) getKubeconfig(ctx context.Context, _ *mcp.CallToolRequest, ar
 	}
 
 	// Standard naming convention for gcloud-generated kubeconfigs
-	newClusterName := fmt.Sprintf("gke_%s_%s_%s", args.ProjectID, args.Location, args.ClusterName)
+	newClusterName := fmt.Sprintf("gke_%s_%s_%s", args.ProjectID, args.Location.Location, args.ClusterName)
 
 	// Initialize a Kubeconfig object
 	pathOptions := clientcmd.NewDefaultPathOptions()
@@ -263,7 +263,7 @@ func (h *handlers) getKubeconfig(ctx context.Context, _ *mcp.CallToolRequest, ar
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
-			&mcp.TextContent{Text: fmt.Sprintf("Kubeconfig for cluster %s (Project: %s, Location: %s) successfully appended/updated in %s. Current context set to %s.", args.ClusterPath(), pathOptions.GlobalFile, newClusterName)},
+			&mcp.TextContent{Text: fmt.Sprintf("Kubeconfig for cluster %s (Project: %s, Location: %s) successfully appended/updated in %s. Current context set to %s.", args.ClusterPath(), args.ProjectID, args.Location.Location, pathOptions.GlobalFile, newClusterName)},
 		},
 	}, nil, nil
 }
@@ -518,20 +518,40 @@ func (h *handlers) getNodeSosReportWithSSH(ctx context.Context, args *getNodeSos
 	}, nil, nil
 }
 
-func (h *handlers) updateCluster(_ context.Context, _ *mcp.CallToolRequest, _ *updateClusterArgs) (*mcp.CallToolResult, any, error) {
-	// TODO: Implement updateCluster
+func (h *handlers) updateCluster(ctx context.Context, _ *mcp.CallToolRequest, args *updateClusterArgs) (*mcp.CallToolResult, any, error) {
+	var updateObj containerpb.ClusterUpdate
+	if err := protojson.Unmarshal([]byte(args.Update), &updateObj); err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal update JSON: %w", err)
+	}
+
+	req := &containerpb.UpdateClusterRequest{
+		Name:   args.ClusterPath(),
+		Update: &updateObj,
+	}
+	resp, err := h.cmClient.UpdateCluster(ctx, req)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
-			&mcp.TextContent{Text: "TODO: Implement updateCluster"},
+			&mcp.TextContent{Text: protojson.Format(resp)},
 		},
 	}, nil, nil
 }
 
-func (h *handlers) deleteCluster(_ context.Context, _ *mcp.CallToolRequest, _ *deleteClusterArgs) (*mcp.CallToolResult, any, error) {
-	// TODO: Implement deleteCluster
+func (h *handlers) deleteCluster(ctx context.Context, _ *mcp.CallToolRequest, args *deleteClusterArgs) (*mcp.CallToolResult, any, error) {
+	req := &containerpb.DeleteClusterRequest{
+		Name: args.ClusterPath(),
+	}
+	resp, err := h.cmClient.DeleteCluster(ctx, req)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
-			&mcp.TextContent{Text: "TODO: Implement deleteCluster"},
+			&mcp.TextContent{Text: protojson.Format(resp)},
 		},
 	}, nil, nil
 }

--- a/pkg/tools/cluster/cluster.go
+++ b/pkg/tools/cluster/cluster.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package cluster provides MCP tools for managing GKE clusters.
 package cluster
 
 import (
@@ -25,17 +24,61 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
 	container "cloud.google.com/go/container/apiv1"
 	containerpb "cloud.google.com/go/container/apiv1/containerpb"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/params"
+	"github.com/googleapis/gax-go/v2/callctx"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"google.golang.org/api/option"
 	"google.golang.org/protobuf/encoding/protojson"
 	"k8s.io/client-go/tools/clientcmd"
 	k8sClientApi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+var (
+	commonClustersFieldMasks = []string{
+		// go/keep-sorted start
+		"autopilot",
+		"createTime",
+		"currentMasterVersion",
+		"currentNodeCount",
+		"currentNodeVersion",
+		"description",
+		"endpoint",
+		"fleet",
+		"location",
+		"name",
+		"network",
+		"nodePools.name",
+		"releaseChannel",
+		"resourceLabels",
+		"selfLink",
+		"status",
+		"statusMessage",
+		"subnetwork",
+		// go/keep-sorted end
+	}
+
+	listClustersFieldMasks = append(prefixStrings(commonClustersFieldMasks, "clusters."),
+		// go/keep-sorted start
+		"missingZones",
+		// go/keep-sorted end
+	)
+
+	getClusterFieldMasks = append(commonClustersFieldMasks,
+		// go/keep-sorted start
+		"nodePools.locations",
+		"nodePools.status",
+		"nodePools.version",
+		// go/keep-sorted end
+	)
+
+	listClustersDefaultFieldMask = initializeDefaultFieldMask(listClustersFieldMasks)
+	getClusterDefaultFieldMask   = initializeDefaultFieldMask(getClusterFieldMasks)
 )
 
 type handlers struct {
@@ -44,106 +87,56 @@ type handlers struct {
 }
 
 type listClustersArgs struct {
-	ProjectID string `json:"project_id,omitempty" jsonschema:"GCP project ID. Use the default if the user doesn't provide it."`
-	Location  string `json:"location,omitempty" jsonschema:"GKE cluster location. Leave this empty if the user doesn't doesn't provide it."`
+	params.LocationOptional
+	ReadMask string `json:"readMask,omitempty" jsonschema:"Optional. The field mask to specify the fields to be returned in the response."`
 }
 
 type getClustersArgs struct {
-	ProjectID string `json:"project_id,omitempty" jsonschema:"GCP project ID. Use the default if the user doesn't provide it."`
-	Location  string `json:"location" jsonschema:"GKE cluster location. Leave this empty if the user doesn't doesn't provide it."`
-	Name      string `json:"name" jsonschema:"GKE cluster name. Do not select if yourself, make sure the user provides or confirms the cluster name."`
+	params.Cluster
+	ReadMask string `json:"readMask,omitempty" jsonschema:"Optional. The field mask to specify the fields to be returned in the response."`
 }
 
 type createClustersArgs struct {
-	ProjectID string              `json:"project_id,omitempty" jsonschema:"GCP project ID. Use the default if the user doesn't provide it."`
-	Location  string              `json:"location" jsonschema:"GKE cluster location. Leave this empty if the user doesn't doesn't provide it."`
-	Cluster   containerpb.Cluster `json:"cluster" jsonschema:"GKE cluster configuration."`
+	params.Location
+	Cluster string `json:"cluster" jsonschema:"Required. A cluster resource represented as a string using JSON format."`
+}
+
+type updateClusterArgs struct {
+	params.Cluster
+	Update string `json:"update" jsonschema:"Required. A description of the update represented as a string using JSON format."`
+}
+
+type deleteClusterArgs struct {
+	params.Cluster
 }
 
 // getKubeconfigArgs defines arguments for getting a GKE cluster's kubeconfig.
 type getKubeconfigArgs struct {
-	ProjectID string `json:"project_id,omitempty" jsonschema:"GCP project ID. Use the default if the user doesn't provide it."`
-	Location  string `json:"location" jsonschema:"GKE cluster location. Leave this empty if the user doesn't provide it."`
-	Name      string `json:"name" jsonschema:"GKE cluster name. Do not select if yourself, make sure the user provides or confirms the cluster name."`
+	params.Cluster
 }
 
 type getNodeSosReportArgs struct {
+	params.Cluster
 	Node           string `json:"node" jsonschema:"GKE node name to collect SOS report from."`
 	Destination    string `json:"destination,omitempty" jsonschema:"Local directory to download the SOS report to. Defaults to /tmp/sos-report if not specified."`
 	Method         string `json:"method,omitempty" jsonschema:"Method to get sos report. Can be 'pod', 'ssh' or 'any'. Defaults to 'any'. When the node is unhealthy from api server, use ssh only."`
 	TimeoutSeconds int    `json:"timeout,omitempty" jsonschema:"Timeout in seconds for the report collection (applies to both pod and ssh methods). Defaults to 180 (3 minutes)."`
 }
 
-// Install registers cluster-related tools with the MCP server.
-func Install(ctx context.Context, s *mcp.Server, c *config.Config) error {
-
-	cmClient, err := container.NewClusterManagerClient(ctx, option.WithUserAgent(c.UserAgent()))
-	if err != nil {
-		return fmt.Errorf("failed to create cluster manager client: %w", err)
-	}
-
-	h := &handlers{
-		c:        c,
-		cmClient: cmClient,
-	}
-
-	mcp.AddTool(s, &mcp.Tool{
-		Name:        "list_clusters",
-		Description: "List GKE clusters. Prefer to use this tool instead of gcloud",
-		Annotations: &mcp.ToolAnnotations{
-			ReadOnlyHint: true,
-		},
-	}, h.listClusters)
-
-	mcp.AddTool(s, &mcp.Tool{
-		Name:        "get_cluster",
-		Description: "Get / describe a GKE cluster. Prefer to use this tool instead of gcloud",
-		Annotations: &mcp.ToolAnnotations{
-			ReadOnlyHint: true,
-		},
-	}, h.getCluster)
-
-	mcp.AddTool(s, &mcp.Tool{
-		Name:        "create_cluster",
-		Description: "Create a GKE cluster. Prefer to use this tool instead of gcloud",
-		Annotations: &mcp.ToolAnnotations{
-			ReadOnlyHint: false,
-		},
-	}, h.createCluster)
-
-	mcp.AddTool(s, &mcp.Tool{
-		Name:        "get_kubeconfig",
-		Description: "Get the kubeconfig for a GKE cluster by calling the GKE API and extracting necessary details (clusterCaCertificate and endpoint). This tool appends/updates the kubeconfig in ~/.kube/config.",
-		Annotations: &mcp.ToolAnnotations{
-			// ReadOnlyHint is removed because this tool now performs a write operation.
-		},
-	}, h.getKubeconfig)
-
-	mcp.AddTool(s, &mcp.Tool{
-		Name:        "get_node_sos_report",
-		Description: "Generate and download an SOS report from a GKE node. Can use 'pod', 'ssh' or 'any' methods. Defaults to 'any' (pod with fallback to ssh). Use 'ssh' if node is API-unhealthy.",
-	}, h.getNodeSosReport)
-
-	return nil
-}
-
 func (h *handlers) listClusters(ctx context.Context, _ *mcp.CallToolRequest, args *listClustersArgs) (*mcp.CallToolResult, any, error) {
-	if args.ProjectID == "" {
-		args.ProjectID = h.c.DefaultProjectID()
-	}
-	if args.Location == "" {
-		args.Location = "-"
-	}
+	ctx = callctx.SetHeaders(ctx,
+		callctx.XGoogFieldMaskHeader,
+		getFieldMask(args.ReadMask, listClustersDefaultFieldMask))
 
 	req := &containerpb.ListClustersRequest{
-		Parent: fmt.Sprintf("projects/%s/locations/%s", args.ProjectID, args.Location),
+		Parent: args.LocationPath(),
 	}
 	resp, err := h.cmClient.ListClusters(ctx, req)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	header := fmt.Sprintf("Found %d clusters in project %s:", len(resp.Clusters), args.ProjectID)
+	header := fmt.Sprintf("Found %d clusters:", len(resp.Clusters))
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
@@ -154,18 +147,12 @@ func (h *handlers) listClusters(ctx context.Context, _ *mcp.CallToolRequest, arg
 }
 
 func (h *handlers) getCluster(ctx context.Context, _ *mcp.CallToolRequest, args *getClustersArgs) (*mcp.CallToolResult, any, error) {
-	if args.ProjectID == "" {
-		args.ProjectID = h.c.DefaultProjectID()
-	}
-	if args.Location == "" {
-		args.Location = h.c.DefaultLocation()
-	}
-	if args.Name == "" {
-		return nil, nil, fmt.Errorf("name argument cannot be empty")
-	}
+	ctx = callctx.SetHeaders(ctx,
+		callctx.XGoogFieldMaskHeader,
+		getFieldMask(args.ReadMask, getClusterDefaultFieldMask))
 
 	req := &containerpb.GetClusterRequest{
-		Name: fmt.Sprintf("projects/%s/locations/%s/clusters/%s", args.ProjectID, args.Location, args.Name),
+		Name: args.ClusterPath(),
 	}
 	resp, err := h.cmClient.GetCluster(ctx, req)
 	if err != nil {
@@ -180,16 +167,14 @@ func (h *handlers) getCluster(ctx context.Context, _ *mcp.CallToolRequest, args 
 }
 
 func (h *handlers) createCluster(ctx context.Context, _ *mcp.CallToolRequest, args *createClustersArgs) (*mcp.CallToolResult, any, error) {
-	if args.ProjectID == "" {
-		args.ProjectID = h.c.DefaultProjectID()
-	}
-	if args.Location == "" {
-		args.Location = h.c.DefaultLocation()
+	var clusterObj containerpb.Cluster
+	if err := protojson.Unmarshal([]byte(args.Cluster), &clusterObj); err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal cluster JSON: %w", err)
 	}
 
 	req := &containerpb.CreateClusterRequest{
-		Parent:  fmt.Sprintf("projects/%s/locations/%s", args.ProjectID, args.Location),
-		Cluster: &args.Cluster,
+		Parent:  args.LocationPath(),
+		Cluster: &clusterObj,
 	}
 	resp, err := h.cmClient.CreateCluster(ctx, req)
 	if err != nil {
@@ -206,32 +191,22 @@ func (h *handlers) createCluster(ctx context.Context, _ *mcp.CallToolRequest, ar
 // getKubeconfig retrieves GKE cluster details and constructs a kubeconfig file.
 // It appends/updates the configuration in the user's ~/.kube/config file.
 func (h *handlers) getKubeconfig(ctx context.Context, _ *mcp.CallToolRequest, args *getKubeconfigArgs) (*mcp.CallToolResult, any, error) {
-	if args.ProjectID == "" {
-		args.ProjectID = h.c.DefaultProjectID()
-	}
-	if args.Location == "" {
-		args.Location = h.c.DefaultLocation()
-	}
-	if args.Name == "" {
-		return nil, nil, fmt.Errorf("name argument cannot be empty")
-	}
-
 	req := &containerpb.GetClusterRequest{
-		Name: fmt.Sprintf("projects/%s/locations/%s/clusters/%s", args.ProjectID, args.Location, args.Name),
+		Name: args.ClusterPath(),
 	}
 	resp, err := h.cmClient.GetCluster(ctx, req)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get cluster %s: %w", args.Name, err)
+		return nil, nil, fmt.Errorf("failed to get cluster %s: %w", args.ClusterPath(), err)
 	}
 
 	clusterCaCertificate := resp.GetMasterAuth().GetClusterCaCertificate()
 	endpoint := resp.GetEndpoint()
 
 	if clusterCaCertificate == "" {
-		return nil, nil, fmt.Errorf("clusterCaCertificate not found for cluster %s", args.Name)
+		return nil, nil, fmt.Errorf("clusterCaCertificate not found for cluster %s", args.ClusterPath())
 	}
 	if endpoint == "" {
-		return nil, nil, fmt.Errorf("endpoint not found for cluster %s", args.Name)
+		return nil, nil, fmt.Errorf("endpoint not found for cluster %s", args.ClusterPath())
 	}
 
 	// Ensure the endpoint starts with "https://"
@@ -240,7 +215,7 @@ func (h *handlers) getKubeconfig(ctx context.Context, _ *mcp.CallToolRequest, ar
 	}
 
 	// Standard naming convention for gcloud-generated kubeconfigs
-	newClusterName := fmt.Sprintf("gke_%s_%s_%s", args.ProjectID, args.Location, args.Name)
+	newClusterName := fmt.Sprintf("gke_%s_%s_%s", args.ProjectID, args.Location, args.ClusterName)
 
 	// Initialize a Kubeconfig object
 	pathOptions := clientcmd.NewDefaultPathOptions()
@@ -288,7 +263,7 @@ func (h *handlers) getKubeconfig(ctx context.Context, _ *mcp.CallToolRequest, ar
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
-			&mcp.TextContent{Text: fmt.Sprintf("Kubeconfig for cluster %s (Project: %s, Location: %s) successfully appended/updated in %s. Current context set to %s.", args.Name, args.ProjectID, args.Location, pathOptions.GlobalFile, newClusterName)},
+			&mcp.TextContent{Text: fmt.Sprintf("Kubeconfig for cluster %s (Project: %s, Location: %s) successfully appended/updated in %s. Current context set to %s.", args.ClusterPath(), pathOptions.GlobalFile, newClusterName)},
 		},
 	}, nil, nil
 }
@@ -541,4 +516,43 @@ func (h *handlers) getNodeSosReportWithSSH(ctx context.Context, args *getNodeSos
 			&mcp.TextContent{Text: fmt.Sprintf("SOS report successfully generated (via SSH) and downloaded to: %s", localPath)},
 		},
 	}, nil, nil
+}
+
+func (h *handlers) updateCluster(_ context.Context, _ *mcp.CallToolRequest, _ *updateClusterArgs) (*mcp.CallToolResult, any, error) {
+	// TODO: Implement updateCluster
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: "TODO: Implement updateCluster"},
+		},
+	}, nil, nil
+}
+
+func (h *handlers) deleteCluster(_ context.Context, _ *mcp.CallToolRequest, _ *deleteClusterArgs) (*mcp.CallToolResult, any, error) {
+	// TODO: Implement deleteCluster
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: "TODO: Implement deleteCluster"},
+		},
+	}, nil, nil
+}
+
+func prefixStrings(fields []string, prefix string) []string {
+	var paths []string
+	for _, field := range fields {
+		paths = append(paths, prefix+field)
+	}
+	return paths
+}
+
+func initializeDefaultFieldMask(fields []string) string {
+	paths := slices.Clone(fields)
+	slices.Sort(paths)
+	return strings.Join(paths, ",")
+}
+
+func getFieldMask(fieldMask string, defaultFieldMask string) string {
+	if fieldMask != "" {
+		return fieldMask
+	}
+	return defaultFieldMask
 }

--- a/pkg/tools/cluster/cluster_test.go
+++ b/pkg/tools/cluster/cluster_test.go
@@ -15,69 +15,59 @@
 package cluster
 
 import (
+	"context"
 	"testing"
 
-	containerpb "cloud.google.com/go/container/apiv1/containerpb"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func TestListClustersArgs_Fields(t *testing.T) {
 	args := listClustersArgs{
-		ProjectID: "test-project",
-		Location:  "us-central1",
+		Parent:   "projects/test-project/locations/us-central1",
+		ReadMask: "name,status",
 	}
 
-	if args.ProjectID != "test-project" {
-		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
+	if args.Parent != "projects/test-project/locations/us-central1" {
+		t.Errorf("Parent = %s, want projects/test-project/locations/us-central1", args.Parent)
 	}
-	if args.Location != "us-central1" {
-		t.Errorf("Location = %s, want us-central1", args.Location)
+	if args.ReadMask != "name,status" {
+		t.Errorf("ReadMask = %s, want name,status", args.ReadMask)
 	}
 }
 
 func TestGetClustersArgs_Fields(t *testing.T) {
 	args := getClustersArgs{
-		ProjectID: "test-project",
-		Location:  "us-central1",
-		Name:      "my-cluster",
+		Name:     "projects/test-project/locations/us-central1/clusters/my-cluster",
+		ReadMask: "name,status",
 	}
 
-	if args.ProjectID != "test-project" {
-		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
+	if args.Name != "projects/test-project/locations/us-central1/clusters/my-cluster" {
+		t.Errorf("Name = %s, want projects/test-project/locations/us-central1/clusters/my-cluster", args.Name)
 	}
-	if args.Location != "us-central1" {
-		t.Errorf("Location = %s, want us-central1", args.Location)
-	}
-	if args.Name != "my-cluster" {
-		t.Errorf("Name = %s, want my-cluster", args.Name)
+	if args.ReadMask != "name,status" {
+		t.Errorf("ReadMask = %s, want name,status", args.ReadMask)
 	}
 }
 
 func TestCreateClustersArgs_Fields(t *testing.T) {
 	args := createClustersArgs{
-		ProjectID: "test-project",
-		Location:  "us-central1",
-		Cluster: containerpb.Cluster{
-			Name: "my-cluster",
-		},
+		Parent:  "projects/test-project/locations/us-central1",
+		Cluster: `{"name": "my-cluster"}`,
 	}
 
-	if args.ProjectID != "test-project" {
-		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
+	if args.Parent != "projects/test-project/locations/us-central1" {
+		t.Errorf("Parent = %s, want projects/test-project/locations/us-central1", args.Parent)
 	}
-	if args.Location != "us-central1" {
-		t.Errorf("Location = %s, want us-central1", args.Location)
-	}
-	if args.Cluster.Name != "my-cluster" {
-		t.Errorf("Name = %s, want my-cluster", args.Cluster.Name)
+	if args.Cluster != `{"name": "my-cluster"}` {
+		t.Errorf("Cluster = %s, want {\"name\": \"my-cluster\"}", args.Cluster)
 	}
 }
 
 func TestGetKubeconfigArgs_Fields(t *testing.T) {
-	args := getKubeconfigArgs{
-		ProjectID: "test-project",
-		Location:  "us-west1",
-		Name:      "my-cluster",
-	}
+	var args getKubeconfigArgs
+	args.ProjectID = "test-project"
+	args.Location = "us-west1"
+	args.ClusterName = "my-cluster"
 
 	if args.ProjectID != "test-project" {
 		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
@@ -85,8 +75,8 @@ func TestGetKubeconfigArgs_Fields(t *testing.T) {
 	if args.Location != "us-west1" {
 		t.Errorf("Location = %s, want us-west1", args.Location)
 	}
-	if args.Name != "my-cluster" {
-		t.Errorf("Name = %s, want my-cluster", args.Name)
+	if args.ClusterName != "my-cluster" {
+		t.Errorf("ClusterName = %s, want my-cluster", args.ClusterName)
 	}
 }
 
@@ -112,97 +102,92 @@ func TestGetNodeSosReportArgs_Fields(t *testing.T) {
 	}
 }
 
-func TestGetNodeSosReportArgs_Defaults(t *testing.T) {
-	args := getNodeSosReportArgs{
-		Node: "my-node",
-	}
-
-	if args.Destination != "" {
-		t.Errorf("Expected empty Destination for default, got %s", args.Destination)
-	}
-	if args.Method != "" {
-		t.Errorf("Expected empty Method for default, got %s", args.Method)
-	}
-	if args.TimeoutSeconds != 0 {
-		t.Errorf("Expected zero TimeoutSeconds for default, got %d", args.TimeoutSeconds)
-	}
-}
-
-func TestGetNodeSosReportArgs_EmptyNode(t *testing.T) {
-	args := getNodeSosReportArgs{}
-	if args.Node != "" {
-		t.Errorf("Expected empty Node, got %s", args.Node)
-	}
-}
-
 func TestListClustersArgs_Empty(t *testing.T) {
 	args := listClustersArgs{}
-	if args.ProjectID != "" {
-		t.Errorf("Expected empty ProjectID, got %s", args.ProjectID)
+	if args.Parent != "" {
+		t.Errorf("Expected empty Parent, got %s", args.Parent)
 	}
-	if args.Location != "" {
-		t.Errorf("Expected empty Location, got %s", args.Location)
+	if args.ReadMask != "" {
+		t.Errorf("Expected empty ReadMask, got %s", args.ReadMask)
 	}
 }
 
 func TestGetClustersArgs_Empty(t *testing.T) {
 	args := getClustersArgs{}
-	if args.ProjectID != "" {
-		t.Errorf("Expected empty ProjectID, got %s", args.ProjectID)
-	}
-	if args.Location != "" {
-		t.Errorf("Expected empty Location, got %s", args.Location)
-	}
 	if args.Name != "" {
 		t.Errorf("Expected empty Name, got %s", args.Name)
 	}
-}
-
-func TestGetKubeconfigArgs_Empty(t *testing.T) {
-	args := getKubeconfigArgs{}
-	if args.ProjectID != "" {
-		t.Errorf("Expected empty ProjectID, got %s", args.ProjectID)
-	}
-	if args.Location != "" {
-		t.Errorf("Expected empty Location, got %s", args.Location)
-	}
-	if args.Name != "" {
-		t.Errorf("Expected empty Name, got %s", args.Name)
+	if args.ReadMask != "" {
+		t.Errorf("Expected empty ReadMask, got %s", args.ReadMask)
 	}
 }
 
-func TestListClustersArgs_JSONTags(t *testing.T) {
-	args := listClustersArgs{
-		ProjectID: "my-project",
-		Location:  "us-east1",
+func TestCreateClustersArgs_Empty(t *testing.T) {
+	args := createClustersArgs{}
+	if args.Parent != "" {
+		t.Errorf("Expected empty Parent, got %s", args.Parent)
 	}
-
-	if args.ProjectID != "my-project" {
-		t.Error("ProjectID field not working correctly")
-	}
-}
-
-func TestGetClustersArgs_JSONTags(t *testing.T) {
-	args := getClustersArgs{
-		ProjectID: "my-project",
-		Location:  "us-east1",
-		Name:      "my-cluster",
-	}
-
-	if args.Name != "my-cluster" {
-		t.Error("Name field not working correctly")
+	if args.Cluster != "" {
+		t.Errorf("Expected empty Cluster, got %s", args.Cluster)
 	}
 }
 
-func TestGetNodeSosReportArgs_JSONTags(t *testing.T) {
-	args := getNodeSosReportArgs{
-		Node:           "gke-test-pool-abc123",
-		Destination:    "/custom/path",
-		Method:         "ssh",
-		TimeoutSeconds: 600,
+func TestUpdateClusterArgs_Fields(t *testing.T) {
+	args := updateClusterArgs{
+		Name:   "projects/test-project/locations/us-central1/clusters/my-cluster",
+		Update: `{"description": "new description"}`,
 	}
 
-	if args.TimeoutSeconds != 600 {
-		t.Error("TimeoutSeconds field not working correctly")
+	if args.Name != "projects/test-project/locations/us-central1/clusters/my-cluster" {
+		t.Errorf("Name = %s, want projects/test-project/locations/us-central1/clusters/my-cluster", args.Name)
+	}
+	if args.Update != `{"description": "new description"}` {
+		t.Errorf("Update = %s, want {\"description\": \"new description\"}", args.Update)
+	}
+}
+
+func TestDeleteClusterArgs_Fields(t *testing.T) {
+	args := deleteClusterArgs{
+		Name: "projects/test-project/locations/us-central1/clusters/my-cluster",
+	}
+
+	if args.Name != "projects/test-project/locations/us-central1/clusters/my-cluster" {
+		t.Errorf("Name = %s, want projects/test-project/locations/us-central1/clusters/my-cluster", args.Name)
+	}
+}
+
+func TestUpdateCluster_Handler(t *testing.T) {
+	h := &handlers{}
+	resp, _, err := h.updateCluster(context.Background(), nil, &updateClusterArgs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Content) != 1 {
+		t.Fatalf("Expected 1 content item, got %d", len(resp.Content))
+	}
+	text, ok := resp.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatal("Expected TextContent")
+	}
+	if text.Text != "TODO: Implement updateCluster" {
+		t.Errorf("Expected 'TODO: Implement updateCluster', got %s", text.Text)
+	}
+}
+
+func TestDeleteCluster_Handler(t *testing.T) {
+	h := &handlers{}
+	resp, _, err := h.deleteCluster(context.Background(), nil, &deleteClusterArgs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Content) != 1 {
+		t.Fatalf("Expected 1 content item, got %d", len(resp.Content))
+	}
+	text, ok := resp.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatal("Expected TextContent")
+	}
+	if text.Text != "TODO: Implement deleteCluster" {
+		t.Errorf("Expected 'TODO: Implement deleteCluster', got %s", text.Text)
 	}
 }

--- a/pkg/tools/cluster/cluster_test.go
+++ b/pkg/tools/cluster/cluster_test.go
@@ -38,15 +38,15 @@ func TestListClustersArgs_Fields(t *testing.T) {
 func TestGetClustersArgs_Fields(t *testing.T) {
 	args := getClustersArgs{}
 	args.ProjectID = "test-project"
-	args.Location.Location = "us-central1"
+	args.Location = "us-central1"
 	args.ClusterName = "my-cluster"
 	args.ReadMask = "name,status"
 
 	if args.ProjectID != "test-project" {
 		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
 	}
-	if args.Location.Location != "us-central1" {
-		t.Errorf("Location = %s, want us-central1", args.Location.Location)
+	if args.Location != "us-central1" {
+		t.Errorf("Location = %s, want us-central1", args.Location)
 	}
 	if args.ClusterName != "my-cluster" {
 		t.Errorf("ClusterName = %s, want my-cluster", args.ClusterName)
@@ -59,14 +59,14 @@ func TestGetClustersArgs_Fields(t *testing.T) {
 func TestCreateClustersArgs_Fields(t *testing.T) {
 	args := createClustersArgs{}
 	args.ProjectID = "test-project"
-	args.Location.Location = "us-central1"
+	args.Location = "us-central1"
 	args.Cluster = `{"name": "my-cluster"}`
 
 	if args.ProjectID != "test-project" {
 		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
 	}
-	if args.Location.Location != "us-central1" {
-		t.Errorf("Location = %s, want us-central1", args.Location.Location)
+	if args.Location != "us-central1" {
+		t.Errorf("Location = %s, want us-central1", args.Location)
 	}
 	if args.Cluster != `{"name": "my-cluster"}` {
 		t.Errorf("Cluster = %s, want {\"name\": \"my-cluster\"}", args.Cluster)
@@ -76,14 +76,14 @@ func TestCreateClustersArgs_Fields(t *testing.T) {
 func TestGetKubeconfigArgs_Fields(t *testing.T) {
 	var args getKubeconfigArgs
 	args.ProjectID = "test-project"
-	args.Location.Location = "us-west1"
+	args.Location = "us-west1"
 	args.ClusterName = "my-cluster"
 
 	if args.ProjectID != "test-project" {
 		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
 	}
-	if args.Location.Location != "us-west1" {
-		t.Errorf("Location = %s, want us-west1", args.Location.Location)
+	if args.Location != "us-west1" {
+		t.Errorf("Location = %s, want us-west1", args.Location)
 	}
 	if args.ClusterName != "my-cluster" {
 		t.Errorf("ClusterName = %s, want my-cluster", args.ClusterName)
@@ -130,8 +130,8 @@ func TestGetClustersArgs_Empty(t *testing.T) {
 	if args.ProjectID != "" {
 		t.Errorf("Expected empty ProjectID, got %s", args.ProjectID)
 	}
-	if args.Location.Location != "" {
-		t.Errorf("Expected empty Location, got %s", args.Location.Location)
+	if args.Location != "" {
+		t.Errorf("Expected empty Location, got %s", args.Location)
 	}
 	if args.ClusterName != "" {
 		t.Errorf("Expected empty ClusterName, got %s", args.ClusterName)
@@ -146,8 +146,8 @@ func TestCreateClustersArgs_Empty(t *testing.T) {
 	if args.ProjectID != "" {
 		t.Errorf("Expected empty ProjectID, got %s", args.ProjectID)
 	}
-	if args.Location.Location != "" {
-		t.Errorf("Expected empty Location, got %s", args.Location.Location)
+	if args.Location != "" {
+		t.Errorf("Expected empty Location, got %s", args.Location)
 	}
 	if args.Cluster != "" {
 		t.Errorf("Expected empty Cluster, got %s", args.Cluster)
@@ -157,15 +157,15 @@ func TestCreateClustersArgs_Empty(t *testing.T) {
 func TestUpdateClusterArgs_Fields(t *testing.T) {
 	args := updateClusterArgs{}
 	args.ProjectID = "test-project"
-	args.Location.Location = "us-central1"
+	args.Location = "us-central1"
 	args.ClusterName = "my-cluster"
 	args.Update = `{"description": "new description"}`
 
 	if args.ProjectID != "test-project" {
 		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
 	}
-	if args.Location.Location != "us-central1" {
-		t.Errorf("Location = %s, want us-central1", args.Location.Location)
+	if args.Location != "us-central1" {
+		t.Errorf("Location = %s, want us-central1", args.Location)
 	}
 	if args.ClusterName != "my-cluster" {
 		t.Errorf("ClusterName = %s, want my-cluster", args.ClusterName)
@@ -178,14 +178,14 @@ func TestUpdateClusterArgs_Fields(t *testing.T) {
 func TestDeleteClusterArgs_Fields(t *testing.T) {
 	args := deleteClusterArgs{}
 	args.ProjectID = "test-project"
-	args.Location.Location = "us-central1"
+	args.Location = "us-central1"
 	args.ClusterName = "my-cluster"
 
 	if args.ProjectID != "test-project" {
 		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
 	}
-	if args.Location.Location != "us-central1" {
-		t.Errorf("Location = %s, want us-central1", args.Location.Location)
+	if args.Location != "us-central1" {
+		t.Errorf("Location = %s, want us-central1", args.Location)
 	}
 	if args.ClusterName != "my-cluster" {
 		t.Errorf("ClusterName = %s, want my-cluster", args.ClusterName)

--- a/pkg/tools/cluster/cluster_test.go
+++ b/pkg/tools/cluster/cluster_test.go
@@ -22,13 +22,16 @@ import (
 )
 
 func TestListClustersArgs_Fields(t *testing.T) {
-	args := listClustersArgs{
-		Parent:   "projects/test-project/locations/us-central1",
-		ReadMask: "name,status",
-	}
+	args := listClustersArgs{}
+	args.ProjectID = "test-project"
+	args.Location = "us-central1"
+	args.ReadMask = "name,status"
 
-	if args.Parent != "projects/test-project/locations/us-central1" {
-		t.Errorf("Parent = %s, want projects/test-project/locations/us-central1", args.Parent)
+	if args.ProjectID != "test-project" {
+		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
+	}
+	if args.Location != "us-central1" {
+		t.Errorf("Location = %s, want us-central1", args.Location)
 	}
 	if args.ReadMask != "name,status" {
 		t.Errorf("ReadMask = %s, want name,status", args.ReadMask)
@@ -36,13 +39,20 @@ func TestListClustersArgs_Fields(t *testing.T) {
 }
 
 func TestGetClustersArgs_Fields(t *testing.T) {
-	args := getClustersArgs{
-		Name:     "projects/test-project/locations/us-central1/clusters/my-cluster",
-		ReadMask: "name,status",
-	}
+	args := getClustersArgs{}
+	args.ProjectID = "test-project"
+	args.Location.Location = "us-central1"
+	args.ClusterName = "my-cluster"
+	args.ReadMask = "name,status"
 
-	if args.Name != "projects/test-project/locations/us-central1/clusters/my-cluster" {
-		t.Errorf("Name = %s, want projects/test-project/locations/us-central1/clusters/my-cluster", args.Name)
+	if args.ProjectID != "test-project" {
+		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
+	}
+	if args.Location.Location != "us-central1" {
+		t.Errorf("Location = %s, want us-central1", args.Location.Location)
+	}
+	if args.ClusterName != "my-cluster" {
+		t.Errorf("ClusterName = %s, want my-cluster", args.ClusterName)
 	}
 	if args.ReadMask != "name,status" {
 		t.Errorf("ReadMask = %s, want name,status", args.ReadMask)
@@ -50,13 +60,16 @@ func TestGetClustersArgs_Fields(t *testing.T) {
 }
 
 func TestCreateClustersArgs_Fields(t *testing.T) {
-	args := createClustersArgs{
-		Parent:  "projects/test-project/locations/us-central1",
-		Cluster: `{"name": "my-cluster"}`,
-	}
+	args := createClustersArgs{}
+	args.ProjectID = "test-project"
+	args.Location.Location = "us-central1"
+	args.Cluster = `{"name": "my-cluster"}`
 
-	if args.Parent != "projects/test-project/locations/us-central1" {
-		t.Errorf("Parent = %s, want projects/test-project/locations/us-central1", args.Parent)
+	if args.ProjectID != "test-project" {
+		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
+	}
+	if args.Location.Location != "us-central1" {
+		t.Errorf("Location = %s, want us-central1", args.Location.Location)
 	}
 	if args.Cluster != `{"name": "my-cluster"}` {
 		t.Errorf("Cluster = %s, want {\"name\": \"my-cluster\"}", args.Cluster)
@@ -66,14 +79,14 @@ func TestCreateClustersArgs_Fields(t *testing.T) {
 func TestGetKubeconfigArgs_Fields(t *testing.T) {
 	var args getKubeconfigArgs
 	args.ProjectID = "test-project"
-	args.Location = "us-west1"
+	args.Location.Location = "us-west1"
 	args.ClusterName = "my-cluster"
 
 	if args.ProjectID != "test-project" {
 		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
 	}
-	if args.Location != "us-west1" {
-		t.Errorf("Location = %s, want us-west1", args.Location)
+	if args.Location.Location != "us-west1" {
+		t.Errorf("Location = %s, want us-west1", args.Location.Location)
 	}
 	if args.ClusterName != "my-cluster" {
 		t.Errorf("ClusterName = %s, want my-cluster", args.ClusterName)
@@ -104,8 +117,11 @@ func TestGetNodeSosReportArgs_Fields(t *testing.T) {
 
 func TestListClustersArgs_Empty(t *testing.T) {
 	args := listClustersArgs{}
-	if args.Parent != "" {
-		t.Errorf("Expected empty Parent, got %s", args.Parent)
+	if args.ProjectID != "" {
+		t.Errorf("Expected empty ProjectID, got %s", args.ProjectID)
+	}
+	if args.Location != "" {
+		t.Errorf("Expected empty Location, got %s", args.Location)
 	}
 	if args.ReadMask != "" {
 		t.Errorf("Expected empty ReadMask, got %s", args.ReadMask)
@@ -114,8 +130,14 @@ func TestListClustersArgs_Empty(t *testing.T) {
 
 func TestGetClustersArgs_Empty(t *testing.T) {
 	args := getClustersArgs{}
-	if args.Name != "" {
-		t.Errorf("Expected empty Name, got %s", args.Name)
+	if args.ProjectID != "" {
+		t.Errorf("Expected empty ProjectID, got %s", args.ProjectID)
+	}
+	if args.Location.Location != "" {
+		t.Errorf("Expected empty Location, got %s", args.Location.Location)
+	}
+	if args.ClusterName != "" {
+		t.Errorf("Expected empty ClusterName, got %s", args.ClusterName)
 	}
 	if args.ReadMask != "" {
 		t.Errorf("Expected empty ReadMask, got %s", args.ReadMask)
@@ -124,8 +146,11 @@ func TestGetClustersArgs_Empty(t *testing.T) {
 
 func TestCreateClustersArgs_Empty(t *testing.T) {
 	args := createClustersArgs{}
-	if args.Parent != "" {
-		t.Errorf("Expected empty Parent, got %s", args.Parent)
+	if args.ProjectID != "" {
+		t.Errorf("Expected empty ProjectID, got %s", args.ProjectID)
+	}
+	if args.Location.Location != "" {
+		t.Errorf("Expected empty Location, got %s", args.Location.Location)
 	}
 	if args.Cluster != "" {
 		t.Errorf("Expected empty Cluster, got %s", args.Cluster)

--- a/pkg/tools/cluster/cluster_test.go
+++ b/pkg/tools/cluster/cluster_test.go
@@ -158,13 +158,20 @@ func TestCreateClustersArgs_Empty(t *testing.T) {
 }
 
 func TestUpdateClusterArgs_Fields(t *testing.T) {
-	args := updateClusterArgs{
-		Name:   "projects/test-project/locations/us-central1/clusters/my-cluster",
-		Update: `{"description": "new description"}`,
-	}
+	args := updateClusterArgs{}
+	args.ProjectID = "test-project"
+	args.Location.Location = "us-central1"
+	args.ClusterName = "my-cluster"
+	args.Update = `{"description": "new description"}`
 
-	if args.Name != "projects/test-project/locations/us-central1/clusters/my-cluster" {
-		t.Errorf("Name = %s, want projects/test-project/locations/us-central1/clusters/my-cluster", args.Name)
+	if args.ProjectID != "test-project" {
+		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
+	}
+	if args.Location.Location != "us-central1" {
+		t.Errorf("Location = %s, want us-central1", args.Location.Location)
+	}
+	if args.ClusterName != "my-cluster" {
+		t.Errorf("ClusterName = %s, want my-cluster", args.ClusterName)
 	}
 	if args.Update != `{"description": "new description"}` {
 		t.Errorf("Update = %s, want {\"description\": \"new description\"}", args.Update)
@@ -172,12 +179,19 @@ func TestUpdateClusterArgs_Fields(t *testing.T) {
 }
 
 func TestDeleteClusterArgs_Fields(t *testing.T) {
-	args := deleteClusterArgs{
-		Name: "projects/test-project/locations/us-central1/clusters/my-cluster",
-	}
+	args := deleteClusterArgs{}
+	args.ProjectID = "test-project"
+	args.Location.Location = "us-central1"
+	args.ClusterName = "my-cluster"
 
-	if args.Name != "projects/test-project/locations/us-central1/clusters/my-cluster" {
-		t.Errorf("Name = %s, want projects/test-project/locations/us-central1/clusters/my-cluster", args.Name)
+	if args.ProjectID != "test-project" {
+		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
+	}
+	if args.Location.Location != "us-central1" {
+		t.Errorf("Location = %s, want us-central1", args.Location.Location)
+	}
+	if args.ClusterName != "my-cluster" {
+		t.Errorf("ClusterName = %s, want my-cluster", args.ClusterName)
 	}
 }
 

--- a/pkg/tools/cluster/cluster_test.go
+++ b/pkg/tools/cluster/cluster_test.go
@@ -15,10 +15,7 @@
 package cluster
 
 import (
-	"context"
 	"testing"
-
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func TestListClustersArgs_Fields(t *testing.T) {
@@ -192,41 +189,5 @@ func TestDeleteClusterArgs_Fields(t *testing.T) {
 	}
 	if args.ClusterName != "my-cluster" {
 		t.Errorf("ClusterName = %s, want my-cluster", args.ClusterName)
-	}
-}
-
-func TestUpdateCluster_Handler(t *testing.T) {
-	h := &handlers{}
-	resp, _, err := h.updateCluster(context.Background(), nil, &updateClusterArgs{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(resp.Content) != 1 {
-		t.Fatalf("Expected 1 content item, got %d", len(resp.Content))
-	}
-	text, ok := resp.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatal("Expected TextContent")
-	}
-	if text.Text != "TODO: Implement updateCluster" {
-		t.Errorf("Expected 'TODO: Implement updateCluster', got %s", text.Text)
-	}
-}
-
-func TestDeleteCluster_Handler(t *testing.T) {
-	h := &handlers{}
-	resp, _, err := h.deleteCluster(context.Background(), nil, &deleteClusterArgs{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(resp.Content) != 1 {
-		t.Fatalf("Expected 1 content item, got %d", len(resp.Content))
-	}
-	text, ok := resp.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatal("Expected TextContent")
-	}
-	if text.Text != "TODO: Implement deleteCluster" {
-		t.Errorf("Expected 'TODO: Implement deleteCluster', got %s", text.Text)
 	}
 }

--- a/pkg/tools/cluster/nodepool.go
+++ b/pkg/tools/cluster/nodepool.go
@@ -1,0 +1,136 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	containerpb "cloud.google.com/go/container/apiv1/containerpb"
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/params"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+type createNodePoolArgs struct {
+	params.Cluster
+	NodePool string `json:"nodePool" jsonschema:"Required. The node pool to create represented as a string using JSON format."`
+}
+
+type listNodePoolsArgs struct {
+	params.Cluster
+}
+
+type getNodePoolArgs struct {
+	params.NodePool
+}
+
+type updateNodePoolArgs struct {
+	params.NodePool
+	Update string `json:"update" jsonschema:"Required. A node pool update request represented as a string using JSON format."`
+}
+
+type deleteNodePoolArgs struct {
+	params.NodePool
+}
+
+func (h *handlers) createNodePool(ctx context.Context, _ *mcp.CallToolRequest, args *createNodePoolArgs) (*mcp.CallToolResult, any, error) {
+	var nodePoolObj containerpb.NodePool
+	if err := protojson.Unmarshal([]byte(args.NodePool), &nodePoolObj); err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal node pool JSON: %w", err)
+	}
+
+	req := &containerpb.CreateNodePoolRequest{
+		Parent:   args.ClusterPath(),
+		NodePool: &nodePoolObj,
+	}
+	resp, err := h.cmClient.CreateNodePool(ctx, req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: protojson.Format(resp)},
+		},
+	}, nil, nil
+}
+
+func (h *handlers) listNodePools(ctx context.Context, _ *mcp.CallToolRequest, args *listNodePoolsArgs) (*mcp.CallToolResult, any, error) {
+	req := &containerpb.ListNodePoolsRequest{
+		Parent: args.ClusterPath(),
+	}
+	resp, err := h.cmClient.ListNodePools(ctx, req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: protojson.Format(resp)},
+		},
+	}, nil, nil
+}
+
+func (h *handlers) getNodePool(ctx context.Context, _ *mcp.CallToolRequest, args *getNodePoolArgs) (*mcp.CallToolResult, any, error) {
+	req := &containerpb.GetNodePoolRequest{
+		Name: args.NodePoolPath(),
+	}
+	resp, err := h.cmClient.GetNodePool(ctx, req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: protojson.Format(resp)},
+		},
+	}, nil, nil
+}
+
+func (h *handlers) updateNodePool(ctx context.Context, _ *mcp.CallToolRequest, args *updateNodePoolArgs) (*mcp.CallToolResult, any, error) {
+	var req containerpb.UpdateNodePoolRequest
+	if err := protojson.Unmarshal([]byte(args.Update), &req); err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal update JSON: %w", err)
+	}
+	req.Name = args.NodePoolPath()
+
+	resp, err := h.cmClient.UpdateNodePool(ctx, &req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: protojson.Format(resp)},
+		},
+	}, nil, nil
+}
+
+func (h *handlers) deleteNodePool(ctx context.Context, _ *mcp.CallToolRequest, args *deleteNodePoolArgs) (*mcp.CallToolResult, any, error) {
+	req := &containerpb.DeleteNodePoolRequest{
+		Name: args.NodePoolPath(),
+	}
+	resp, err := h.cmClient.DeleteNodePool(ctx, req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: protojson.Format(resp)},
+		},
+	}, nil, nil
+}

--- a/pkg/tools/cluster/nodepool_test.go
+++ b/pkg/tools/cluster/nodepool_test.go
@@ -1,0 +1,124 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"testing"
+)
+
+func TestCreateNodePoolArgs_Fields(t *testing.T) {
+	args := createNodePoolArgs{}
+	args.ProjectID = "test-project"
+	args.Location.Location = "us-central1"
+	args.ClusterName = "my-cluster"
+	args.NodePool = `{"name": "my-pool"}`
+
+	if args.ProjectID != "test-project" {
+		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
+	}
+	if args.Location.Location != "us-central1" {
+		t.Errorf("Location = %s, want us-central1", args.Location.Location)
+	}
+	if args.ClusterName != "my-cluster" {
+		t.Errorf("ClusterName = %s, want my-cluster", args.ClusterName)
+	}
+	if args.NodePool != `{"name": "my-pool"}` {
+		t.Errorf("NodePool = %s, want {\"name\": \"my-pool\"}", args.NodePool)
+	}
+}
+
+func TestListNodePoolsArgs_Fields(t *testing.T) {
+	args := listNodePoolsArgs{}
+	args.ProjectID = "test-project"
+	args.Location.Location = "us-central1"
+	args.ClusterName = "my-cluster"
+
+	if args.ProjectID != "test-project" {
+		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
+	}
+	if args.Location.Location != "us-central1" {
+		t.Errorf("Location = %s, want us-central1", args.Location.Location)
+	}
+	if args.ClusterName != "my-cluster" {
+		t.Errorf("ClusterName = %s, want my-cluster", args.ClusterName)
+	}
+}
+
+func TestGetNodePoolArgs_Fields(t *testing.T) {
+	args := getNodePoolArgs{}
+	args.ProjectID = "test-project"
+	args.Location.Location = "us-central1"
+	args.ClusterName = "my-cluster"
+	args.NodePoolName = "my-pool"
+
+	if args.ProjectID != "test-project" {
+		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
+	}
+	if args.Location.Location != "us-central1" {
+		t.Errorf("Location = %s, want us-central1", args.Location.Location)
+	}
+	if args.ClusterName != "my-cluster" {
+		t.Errorf("ClusterName = %s, want my-cluster", args.ClusterName)
+	}
+	if args.NodePoolName != "my-pool" {
+		t.Errorf("NodePoolName = %s, want my-pool", args.NodePoolName)
+	}
+}
+
+func TestUpdateNodePoolArgs_Fields(t *testing.T) {
+	args := updateNodePoolArgs{}
+	args.ProjectID = "test-project"
+	args.Location.Location = "us-central1"
+	args.ClusterName = "my-cluster"
+	args.NodePoolName = "my-pool"
+	args.Update = `{"nodeCount": 5}`
+
+	if args.ProjectID != "test-project" {
+		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
+	}
+	if args.Location.Location != "us-central1" {
+		t.Errorf("Location = %s, want us-central1", args.Location.Location)
+	}
+	if args.ClusterName != "my-cluster" {
+		t.Errorf("ClusterName = %s, want my-cluster", args.ClusterName)
+	}
+	if args.NodePoolName != "my-pool" {
+		t.Errorf("NodePoolName = %s, want my-pool", args.NodePoolName)
+	}
+	if args.Update != `{"nodeCount": 5}` {
+		t.Errorf("Update = %s, want {\"nodeCount\": 5}", args.Update)
+	}
+}
+
+func TestDeleteNodePoolArgs_Fields(t *testing.T) {
+	args := deleteNodePoolArgs{}
+	args.ProjectID = "test-project"
+	args.Location.Location = "us-central1"
+	args.ClusterName = "my-cluster"
+	args.NodePoolName = "my-pool"
+
+	if args.ProjectID != "test-project" {
+		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
+	}
+	if args.Location.Location != "us-central1" {
+		t.Errorf("Location = %s, want us-central1", args.Location.Location)
+	}
+	if args.ClusterName != "my-cluster" {
+		t.Errorf("ClusterName = %s, want my-cluster", args.ClusterName)
+	}
+	if args.NodePoolName != "my-pool" {
+		t.Errorf("NodePoolName = %s, want my-pool", args.NodePoolName)
+	}
+}

--- a/pkg/tools/cluster/nodepool_test.go
+++ b/pkg/tools/cluster/nodepool_test.go
@@ -21,15 +21,15 @@ import (
 func TestCreateNodePoolArgs_Fields(t *testing.T) {
 	args := createNodePoolArgs{}
 	args.ProjectID = "test-project"
-	args.Location.Location = "us-central1"
+	args.Location = "us-central1"
 	args.ClusterName = "my-cluster"
 	args.NodePool = `{"name": "my-pool"}`
 
 	if args.ProjectID != "test-project" {
 		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
 	}
-	if args.Location.Location != "us-central1" {
-		t.Errorf("Location = %s, want us-central1", args.Location.Location)
+	if args.Location != "us-central1" {
+		t.Errorf("Location = %s, want us-central1", args.Location)
 	}
 	if args.ClusterName != "my-cluster" {
 		t.Errorf("ClusterName = %s, want my-cluster", args.ClusterName)
@@ -42,14 +42,14 @@ func TestCreateNodePoolArgs_Fields(t *testing.T) {
 func TestListNodePoolsArgs_Fields(t *testing.T) {
 	args := listNodePoolsArgs{}
 	args.ProjectID = "test-project"
-	args.Location.Location = "us-central1"
+	args.Location = "us-central1"
 	args.ClusterName = "my-cluster"
 
 	if args.ProjectID != "test-project" {
 		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
 	}
-	if args.Location.Location != "us-central1" {
-		t.Errorf("Location = %s, want us-central1", args.Location.Location)
+	if args.Location != "us-central1" {
+		t.Errorf("Location = %s, want us-central1", args.Location)
 	}
 	if args.ClusterName != "my-cluster" {
 		t.Errorf("ClusterName = %s, want my-cluster", args.ClusterName)
@@ -59,15 +59,15 @@ func TestListNodePoolsArgs_Fields(t *testing.T) {
 func TestGetNodePoolArgs_Fields(t *testing.T) {
 	args := getNodePoolArgs{}
 	args.ProjectID = "test-project"
-	args.Location.Location = "us-central1"
+	args.Location = "us-central1"
 	args.ClusterName = "my-cluster"
 	args.NodePoolName = "my-pool"
 
 	if args.ProjectID != "test-project" {
 		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
 	}
-	if args.Location.Location != "us-central1" {
-		t.Errorf("Location = %s, want us-central1", args.Location.Location)
+	if args.Location != "us-central1" {
+		t.Errorf("Location = %s, want us-central1", args.Location)
 	}
 	if args.ClusterName != "my-cluster" {
 		t.Errorf("ClusterName = %s, want my-cluster", args.ClusterName)
@@ -80,7 +80,7 @@ func TestGetNodePoolArgs_Fields(t *testing.T) {
 func TestUpdateNodePoolArgs_Fields(t *testing.T) {
 	args := updateNodePoolArgs{}
 	args.ProjectID = "test-project"
-	args.Location.Location = "us-central1"
+	args.Location = "us-central1"
 	args.ClusterName = "my-cluster"
 	args.NodePoolName = "my-pool"
 	args.Update = `{"nodeCount": 5}`
@@ -88,8 +88,8 @@ func TestUpdateNodePoolArgs_Fields(t *testing.T) {
 	if args.ProjectID != "test-project" {
 		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
 	}
-	if args.Location.Location != "us-central1" {
-		t.Errorf("Location = %s, want us-central1", args.Location.Location)
+	if args.Location != "us-central1" {
+		t.Errorf("Location = %s, want us-central1", args.Location)
 	}
 	if args.ClusterName != "my-cluster" {
 		t.Errorf("ClusterName = %s, want my-cluster", args.ClusterName)
@@ -105,15 +105,15 @@ func TestUpdateNodePoolArgs_Fields(t *testing.T) {
 func TestDeleteNodePoolArgs_Fields(t *testing.T) {
 	args := deleteNodePoolArgs{}
 	args.ProjectID = "test-project"
-	args.Location.Location = "us-central1"
+	args.Location = "us-central1"
 	args.ClusterName = "my-cluster"
 	args.NodePoolName = "my-pool"
 
 	if args.ProjectID != "test-project" {
 		t.Errorf("ProjectID = %s, want test-project", args.ProjectID)
 	}
-	if args.Location.Location != "us-central1" {
-		t.Errorf("Location = %s, want us-central1", args.Location.Location)
+	if args.Location != "us-central1" {
+		t.Errorf("Location = %s, want us-central1", args.Location)
 	}
 	if args.ClusterName != "my-cluster" {
 		t.Errorf("ClusterName = %s, want my-cluster", args.ClusterName)

--- a/pkg/tools/cluster/operation.go
+++ b/pkg/tools/cluster/operation.go
@@ -1,0 +1,94 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	containerpb "cloud.google.com/go/container/apiv1/containerpb"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+type listOperationsArgs struct {
+	Parent string `json:"parent" jsonschema:"Required. The parent (project and location) where the operations will be listed. Specified in the format projects/*/locations/*."`
+}
+
+type getOperationArgs struct {
+	Name string `json:"name" jsonschema:"Required. The name (project, location, operation id) of the operation to get. Specified in the format projects/*/locations/*/operations/*."`
+}
+
+type cancelOperationArgs struct {
+	Name   string `json:"name" jsonschema:"Required. The name (project, location, operation id) of the operation to cancel. Specified in the format projects/*/locations/*/operations/*."`
+	Parent string `json:"parent" jsonschema:"Required. The parent cluster of the operation. Specified in the format projects/*/locations/*/clusters/*."`
+}
+
+func (h *handlers) listOperations(ctx context.Context, _ *mcp.CallToolRequest, args *listOperationsArgs) (*mcp.CallToolResult, any, error) {
+	if h.cmClient == nil {
+		return nil, nil, fmt.Errorf("client not initialized")
+	}
+	req := &containerpb.ListOperationsRequest{
+		Parent: args.Parent,
+	}
+	resp, err := h.cmClient.ListOperations(ctx, req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: protojson.Format(resp)},
+		},
+	}, nil, nil
+}
+
+func (h *handlers) getOperation(ctx context.Context, _ *mcp.CallToolRequest, args *getOperationArgs) (*mcp.CallToolResult, any, error) {
+	if h.cmClient == nil {
+		return nil, nil, fmt.Errorf("client not initialized")
+	}
+	req := &containerpb.GetOperationRequest{
+		Name: args.Name,
+	}
+	resp, err := h.cmClient.GetOperation(ctx, req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: protojson.Format(resp)},
+		},
+	}, nil, nil
+}
+
+func (h *handlers) cancelOperation(ctx context.Context, _ *mcp.CallToolRequest, args *cancelOperationArgs) (*mcp.CallToolResult, any, error) {
+	if h.cmClient == nil {
+		return nil, nil, fmt.Errorf("client not initialized")
+	}
+	req := &containerpb.CancelOperationRequest{
+		Name: args.Name,
+	}
+	err := h.cmClient.CancelOperation(ctx, req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: fmt.Sprintf("Operation %s cancelled successfully.", args.Name)},
+		},
+	}, nil, nil
+}

--- a/pkg/tools/cluster/operation_test.go
+++ b/pkg/tools/cluster/operation_test.go
@@ -1,0 +1,87 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"context"
+	"testing"
+)
+
+func TestListOperationsArgs_Fields(t *testing.T) {
+	args := listOperationsArgs{
+		Parent: "projects/test-project/locations/us-central1",
+	}
+
+	if args.Parent != "projects/test-project/locations/us-central1" {
+		t.Errorf("Parent = %s, want projects/test-project/locations/us-central1", args.Parent)
+	}
+}
+
+func TestGetOperationArgs_Fields(t *testing.T) {
+	args := getOperationArgs{
+		Name: "projects/test-project/locations/us-central1/operations/my-op",
+	}
+
+	if args.Name != "projects/test-project/locations/us-central1/operations/my-op" {
+		t.Errorf("Name = %s, want projects/test-project/locations/us-central1/operations/my-op", args.Name)
+	}
+}
+
+func TestCancelOperationArgs_Fields(t *testing.T) {
+	args := cancelOperationArgs{
+		Name:   "projects/test-project/locations/us-central1/operations/my-op",
+		Parent: "projects/test-project/locations/us-central1/clusters/my-cluster",
+	}
+
+	if args.Name != "projects/test-project/locations/us-central1/operations/my-op" {
+		t.Errorf("Name = %s, want projects/test-project/locations/us-central1/operations/my-op", args.Name)
+	}
+	if args.Parent != "projects/test-project/locations/us-central1/clusters/my-cluster" {
+		t.Errorf("Parent = %s, want projects/test-project/locations/us-central1/clusters/my-cluster", args.Parent)
+	}
+}
+
+func TestListOperations_Handler(t *testing.T) {
+	h := &handlers{}
+	_, _, err := h.listOperations(context.Background(), nil, &listOperationsArgs{})
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+	if err.Error() != "client not initialized" {
+		t.Errorf("Expected 'client not initialized', got %v", err)
+	}
+}
+
+func TestGetOperation_Handler(t *testing.T) {
+	h := &handlers{}
+	_, _, err := h.getOperation(context.Background(), nil, &getOperationArgs{})
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+	if err.Error() != "client not initialized" {
+		t.Errorf("Expected 'client not initialized', got %v", err)
+	}
+}
+
+func TestCancelOperation_Handler(t *testing.T) {
+	h := &handlers{}
+	_, _, err := h.cancelOperation(context.Background(), nil, &cancelOperationArgs{})
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+	if err.Error() != "client not initialized" {
+		t.Errorf("Expected 'client not initialized', got %v", err)
+	}
+}

--- a/pkg/tools/cluster/tools.go
+++ b/pkg/tools/cluster/tools.go
@@ -40,7 +40,7 @@ func Install(ctx context.Context, s *mcp.Server, c *config.Config) error {
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "list_clusters",
-		Description: "List GKE clusters. Prefer to use this tool instead of gcloud",
+		Description: "List GKE clusters. Prefer to use this tool instead of gcloud.",
 		Annotations: &mcp.ToolAnnotations{
 			ReadOnlyHint: true,
 		},
@@ -48,15 +48,19 @@ func Install(ctx context.Context, s *mcp.Server, c *config.Config) error {
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "get_cluster",
-		Description: "Get / describe a GKE cluster. Prefer to use this tool instead of gcloud",
+		Description: "Get / describe a GKE cluster. Prefer to use this tool instead of gcloud.",
 		Annotations: &mcp.ToolAnnotations{
 			ReadOnlyHint: true,
 		},
 	}, h.getCluster)
 
 	mcp.AddTool(s, &mcp.Tool{
-		Name:        "create_cluster",
-		Description: "Create a GKE cluster. Prefer to use this tool instead of gcloud",
+		Name: "create_cluster",
+		Description: `Create a GKE cluster. Prefer to use this tool instead of gcloud.
+It's recommended to read the [GKE documentation](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/configuration-overview) to understand cluster configuration options.
+Autopilot mode (autopilot.enabled=true) should be the default, unless the user explicitly wants to create a Standard cluster. You SHOULD always explicitly set autopilot.enabled=(true|false).
+Note: Autopilot mode is only support in regional locations, not in zone.
+This is similar to running "gcloud container clusters create-auto" or "gcloud container clusters create".`,
 		Annotations: &mcp.ToolAnnotations{
 			ReadOnlyHint: false,
 		},
@@ -77,57 +81,15 @@ func Install(ctx context.Context, s *mcp.Server, c *config.Config) error {
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "update_cluster",
-		Description: "Update a GKE cluster. TODO: Implement this.",
+		Description: "Update a GKE cluster. Prefer to use this tool instead of gcloud.",
 	}, h.updateCluster)
 
 	if c.EnableDeleteTools() {
 		mcp.AddTool(s, &mcp.Tool{
 			Name:        "delete_cluster",
-			Description: "Delete a GKE cluster. TODO: Implement this.",
+			Description: "Delete a GKE cluster. Prefer to use this tool instead of gcloud.",
 		}, h.deleteCluster)
 	}
-
-	mcp.AddTool(s, &mcp.Tool{
-		Name:        "create_node_pool",
-		Description: "Create a GKE node pool. TODO: Implement this.",
-	}, h.createNodePool)
-
-	mcp.AddTool(s, &mcp.Tool{
-		Name:        "list_node_pools",
-		Description: "List GKE node pools. TODO: Implement this.",
-	}, h.listNodePools)
-
-	mcp.AddTool(s, &mcp.Tool{
-		Name:        "get_node_pool",
-		Description: "Get a GKE node pool. TODO: Implement this.",
-	}, h.getNodePool)
-
-	mcp.AddTool(s, &mcp.Tool{
-		Name:        "update_node_pool",
-		Description: "Update a GKE node pool. TODO: Implement this.",
-	}, h.updateNodePool)
-
-	if c.EnableDeleteTools() {
-		mcp.AddTool(s, &mcp.Tool{
-			Name:        "delete_node_pool",
-			Description: "Delete a GKE node pool. TODO: Implement this.",
-		}, h.deleteNodePool)
-	}
-
-	mcp.AddTool(s, &mcp.Tool{
-		Name:        "list_operations",
-		Description: "List GKE operations. TODO: Implement this.",
-	}, h.listOperations)
-
-	mcp.AddTool(s, &mcp.Tool{
-		Name:        "get_operation",
-		Description: "Get a GKE operation. TODO: Implement this.",
-	}, h.getOperation)
-
-	mcp.AddTool(s, &mcp.Tool{
-		Name:        "cancel_operation",
-		Description: "Cancel a GKE operation. TODO: Implement this.",
-	}, h.cancelOperation)
 
 	return nil
 }

--- a/pkg/tools/cluster/tools.go
+++ b/pkg/tools/cluster/tools.go
@@ -84,11 +84,42 @@ This is similar to running "gcloud container clusters create-auto" or "gcloud co
 		Description: "Update a GKE cluster. Prefer to use this tool instead of gcloud.",
 	}, h.updateCluster)
 
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "list_node_pools",
+		Description: "List node pools in a GKE cluster.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+	}, h.listNodePools)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "get_node_pool",
+		Description: "Get details of a GKE node pool.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+	}, h.getNodePool)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "create_node_pool",
+		Description: "Create a new node pool in a GKE cluster.",
+	}, h.createNodePool)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "update_node_pool",
+		Description: "Update a GKE node pool.",
+	}, h.updateNodePool)
+
 	if c.EnableDeleteTools() {
 		mcp.AddTool(s, &mcp.Tool{
 			Name:        "delete_cluster",
 			Description: "Delete a GKE cluster. Prefer to use this tool instead of gcloud.",
 		}, h.deleteCluster)
+
+		mcp.AddTool(s, &mcp.Tool{
+			Name:        "delete_node_pool",
+			Description: "Delete a GKE node pool.",
+		}, h.deleteNodePool)
 	}
 
 	return nil

--- a/pkg/tools/cluster/tools.go
+++ b/pkg/tools/cluster/tools.go
@@ -110,6 +110,27 @@ This is similar to running "gcloud container clusters create-auto" or "gcloud co
 		Description: "Update a GKE node pool.",
 	}, h.updateNodePool)
 
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "list_operations",
+		Description: "List GKE operations in a project and location.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+	}, h.listOperations)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "get_operation",
+		Description: "Get details of a GKE operation.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+	}, h.getOperation)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "cancel_operation",
+		Description: "Cancel a GKE operation.",
+	}, h.cancelOperation)
+
 	if c.EnableDeleteTools() {
 		mcp.AddTool(s, &mcp.Tool{
 			Name:        "delete_cluster",

--- a/pkg/tools/cluster/tools.go
+++ b/pkg/tools/cluster/tools.go
@@ -1,0 +1,133 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cluster provides MCP tools for managing GKE clusters.
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	container "cloud.google.com/go/container/apiv1"
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"google.golang.org/api/option"
+)
+
+// Install registers cluster-related tools with the MCP server.
+func Install(ctx context.Context, s *mcp.Server, c *config.Config) error {
+
+	cmClient, err := container.NewClusterManagerClient(ctx, option.WithUserAgent(c.UserAgent()))
+	if err != nil {
+		return fmt.Errorf("failed to create cluster manager client: %w", err)
+	}
+
+	h := &handlers{
+		c:        c,
+		cmClient: cmClient,
+	}
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "list_clusters",
+		Description: "List GKE clusters. Prefer to use this tool instead of gcloud",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+	}, h.listClusters)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "get_cluster",
+		Description: "Get / describe a GKE cluster. Prefer to use this tool instead of gcloud",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+	}, h.getCluster)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "create_cluster",
+		Description: "Create a GKE cluster. Prefer to use this tool instead of gcloud",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint: false,
+		},
+	}, h.createCluster)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "get_kubeconfig",
+		Description: "Get the kubeconfig for a GKE cluster by calling the GKE API and extracting necessary details (clusterCaCertificate and endpoint). This tool appends/updates the kubeconfig in ~/.kube/config.",
+		Annotations: &mcp.ToolAnnotations{
+			// ReadOnlyHint is removed because this tool now performs a write operation.
+		},
+	}, h.getKubeconfig)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "get_node_sos_report",
+		Description: "Generate and download an SOS report from a GKE node. Can use 'pod', 'ssh' or 'any' methods. Defaults to 'any' (pod with fallback to ssh). Use 'ssh' if node is API-unhealthy.",
+	}, h.getNodeSosReport)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "update_cluster",
+		Description: "Update a GKE cluster. TODO: Implement this.",
+	}, h.updateCluster)
+
+	if c.EnableDeleteTools() {
+		mcp.AddTool(s, &mcp.Tool{
+			Name:        "delete_cluster",
+			Description: "Delete a GKE cluster. TODO: Implement this.",
+		}, h.deleteCluster)
+	}
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "create_node_pool",
+		Description: "Create a GKE node pool. TODO: Implement this.",
+	}, h.createNodePool)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "list_node_pools",
+		Description: "List GKE node pools. TODO: Implement this.",
+	}, h.listNodePools)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "get_node_pool",
+		Description: "Get a GKE node pool. TODO: Implement this.",
+	}, h.getNodePool)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "update_node_pool",
+		Description: "Update a GKE node pool. TODO: Implement this.",
+	}, h.updateNodePool)
+
+	if c.EnableDeleteTools() {
+		mcp.AddTool(s, &mcp.Tool{
+			Name:        "delete_node_pool",
+			Description: "Delete a GKE node pool. TODO: Implement this.",
+		}, h.deleteNodePool)
+	}
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "list_operations",
+		Description: "List GKE operations. TODO: Implement this.",
+	}, h.listOperations)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "get_operation",
+		Description: "Get a GKE operation. TODO: Implement this.",
+	}, h.getOperation)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "cancel_operation",
+		Description: "Cancel a GKE operation. TODO: Implement this.",
+	}, h.cancelOperation)
+
+	return nil
+}

--- a/pkg/tools/params/params.go
+++ b/pkg/tools/params/params.go
@@ -1,0 +1,56 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package params provide common tool parameter types.
+package params
+
+import "fmt"
+
+type Project struct {
+	ProjectID string `json:"project_id" jsonschema:"Required. GCP project ID."`
+}
+
+func (p *Project) ProjectIDPath() string {
+	return fmt.Sprintf("projects/%s", p.ProjectID)
+}
+
+type Location struct {
+	Project
+	Location string `json:"location" jsonschema:"Required. GKE cluster location."`
+}
+
+func (l *Location) LocationPath() string {
+	return fmt.Sprintf("%s/locations/%s", l.ProjectIDPath(), l.Location)
+}
+
+type LocationOptional struct {
+	Project
+	Location string `json:"location,omitempty" jsonschema:"Optional. GKE cluster location."`
+}
+
+func (l *LocationOptional) LocationPath() string {
+	if l.Location == "" {
+		return fmt.Sprintf("%s/locations/-", l.ProjectIDPath())
+	}
+	return fmt.Sprintf("%s/locations/%s", l.ProjectIDPath(), l.Location)
+}
+
+type Cluster struct {
+	Location
+	ClusterName string `json:"cluster_name" jsonschema:"Required. GKE cluster name."`
+}
+
+func (c *Cluster) ClusterPath() string {
+	return fmt.Sprintf("%s/clusters/%s", c.LocationPath(), c.ClusterName)
+}

--- a/pkg/tools/params/params.go
+++ b/pkg/tools/params/params.go
@@ -25,18 +25,18 @@ func (p *Project) ProjectIDPath() string {
 	return fmt.Sprintf("projects/%s", p.ProjectID)
 }
 
-type Location struct {
+type LocationRequired struct {
 	Project
-	Location string `json:"location" jsonschema:"Required. GKE cluster location."`
+	Location string `json:"location" jsonschema:"Required to be a valid GCP region or zone. MUST NOT be empty."`
 }
 
-func (l *Location) LocationPath() string {
+func (l *LocationRequired) LocationPath() string {
 	return fmt.Sprintf("%s/locations/%s", l.ProjectIDPath(), l.Location)
 }
 
 type LocationOptional struct {
 	Project
-	Location string `json:"location,omitempty" jsonschema:"Optional. GKE cluster location."`
+	Location string `json:"location,omitempty" jsonschema:"Optional. GCP region or zone."`
 }
 
 func (l *LocationOptional) LocationPath() string {
@@ -47,10 +47,21 @@ func (l *LocationOptional) LocationPath() string {
 }
 
 type Cluster struct {
-	Location
+	LocationRequired
 	ClusterName string `json:"cluster_name" jsonschema:"Required. GKE cluster name."`
 }
 
 func (c *Cluster) ClusterPath() string {
 	return fmt.Sprintf("%s/clusters/%s", c.LocationPath(), c.ClusterName)
+}
+
+// NodePool represents GKE node pool parameters.
+type NodePool struct {
+	Cluster
+	NodePoolName string `json:"node_pool_name" jsonschema:"Required. GKE node pool name."`
+}
+
+// NodePoolPath returns the full resource path for the node pool.
+func (n *NodePool) NodePoolPath() string {
+	return fmt.Sprintf("%s/nodePools/%s", n.ClusterPath(), n.NodePoolName)
 }

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -24,6 +24,7 @@ import (
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/clustertoolkit"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/deploy"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/gkereleasenotes"
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/k8s"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/k8schangelog"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/logging"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/monitoring"
@@ -45,6 +46,7 @@ func Install(ctx context.Context, s *mcp.Server, c *config.Config) error {
 		k8schangelog.Install,
 		gkereleasenotes.Install,
 		manifestgen.Install,
+		k8s.Install,
 	}
 
 	for _, installer := range installers {


### PR DESCRIPTION
## 🎯 Why This Change?
This PR implements GKE operations tools in the MCP server, allowing users to list, get, and cancel operations. This enhances the server's capabilities to monitor and manage long-running GKE operations.

## 📝 What Changed?
- `pkg/tools/cluster/operation.go`: Implemented `listOperations`, `getOperation`, and `cancelOperation` handlers with safety checks for initialized client.
- `pkg/tools/cluster/operation_test.go`: Updated tests to assert expected behavior (error on nil client) instead of TODO strings.
- `pkg/tools/cluster/tools.go`: Registered the new tools: `list_operations`, `get_operation`, and `cancel_operation`.

## ✅ Verification Results
- All unit tests passed.
- Presubmit checks passed successfully.
