### PR TITLE
Implement FetchModelServerVersions in giq package

### DIFF
--- a/pkg/tools/giq/giq.go
+++ b/pkg/tools/giq/giq.go
@@ -196,3 +196,47 @@ func FetchProfiles(ctx context.Context, model, modelServer, modelServerVersion s
 	}
 	return strings.Join(output, "\n---\n"), nil
 }
+
+var fetchModelServerVersionsFunc = func(ctx context.Context, model, modelServer string) ([]string, error) {
+	client, err := gkerecommender.NewGkeInferenceQuickstartClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gkerecommender client: %w", err)
+	}
+	defer func() {
+		_ = client.Close()
+	}()
+
+	req := &gkerecommenderpb.FetchModelServerVersionsRequest{
+		Model:       model,
+		ModelServer: modelServer,
+	}
+	it := client.FetchModelServerVersions(ctx, req)
+
+	var versions []string
+	for {
+		resp, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch next model server version: %w", err)
+		}
+		versions = append(versions, resp)
+	}
+	return versions, nil
+}
+
+// FetchModelServerVersions fetches available model server versions for a given model and model server.
+func FetchModelServerVersions(ctx context.Context, model, modelServer string) (string, error) {
+	if model == "" {
+		return "", fmt.Errorf("model argument cannot be empty")
+	}
+	if modelServer == "" {
+		return "", fmt.Errorf("model_server argument cannot be empty")
+	}
+	versions, err := fetchModelServerVersionsFunc(ctx, model, modelServer)
+	if err != nil {
+		return "", err
+	}
+	return strings.Join(versions, "\n"), nil
+}

--- a/pkg/tools/giq/giq_test.go
+++ b/pkg/tools/giq/giq_test.go
@@ -216,3 +216,39 @@ func TestFetchProfiles_Mock(t *testing.T) {
 		t.Errorf("Expected result to contain 'nvidia-l4', got %q", res)
 	}
 }
+
+func TestFetchModelServerVersions_Mock(t *testing.T) {
+	originalFunc := fetchModelServerVersionsFunc
+	defer func() { fetchModelServerVersionsFunc = originalFunc }()
+
+	fetchModelServerVersionsFunc = func(_ context.Context, model, modelServer string) ([]string, error) {
+		if model != "test-model" {
+			t.Errorf("Expected model 'test-model', got %q", model)
+		}
+		if modelServer != "test-server" {
+			t.Errorf("Expected modelServer 'test-server', got %q", modelServer)
+		}
+		return []string{"v1", "v2"}, nil
+	}
+
+	res, err := FetchModelServerVersions(context.Background(), "test-model", "test-server")
+	if err != nil {
+		t.Fatalf("FetchModelServerVersions returned error: %v", err)
+	}
+
+	expected := "v1\nv2"
+	if res != expected {
+		t.Errorf("FetchModelServerVersions = %q, want %q", res, expected)
+	}
+}
+
+func TestFetchModelServerVersions_Validation(t *testing.T) {
+	_, err := FetchModelServerVersions(context.Background(), "", "server")
+	if err == nil {
+		t.Error("Expected error for empty model, got nil")
+	}
+	_, err = FetchModelServerVersions(context.Background(), "model", "")
+	if err == nil {
+		t.Error("Expected error for empty modelServer, got nil")
+	}
+}


### PR DESCRIPTION
## 🎯 Why This Change?
This PR implements the `FetchModelServerVersions` function in the `giq` package to call the GKE Recommender API SDK. This supports fetching valid model server versions for a given model and server in GKE Inference Quickstart workflows.

## 📝 What Changed?
File: `pkg/tools/giq/giq.go`
- Added `FetchModelServerVersions` function.
- Added `fetchModelServerVersionsFunc` for mocking.

File: `pkg/tools/giq/giq_test.go`
- Added `TestFetchModelServerVersions_Mock`.

## ✅ Testing
- Unit tests passed: `go test ./pkg/tools/giq/...`
- Full presubmit checks passed.

Ref #330
