### PR TITLE
Implement FetchProfiles in giq package

### DIFF
--- a/pkg/tools/giq/giq.go
+++ b/pkg/tools/giq/giq.go
@@ -152,3 +152,47 @@ func FetchModelServers(ctx context.Context, model string) (string, error) {
 	}
 	return strings.Join(servers, "\n"), nil
 }
+
+var fetchProfilesFunc = func(ctx context.Context, model, modelServer, modelServerVersion string) ([]*gkerecommenderpb.Profile, error) {
+	client, err := gkerecommender.NewGkeInferenceQuickstartClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gkerecommender client: %w", err)
+	}
+	defer func() {
+		_ = client.Close()
+	}()
+
+	req := &gkerecommenderpb.FetchProfilesRequest{
+		Model:              model,
+		ModelServer:        modelServer,
+		ModelServerVersion: modelServerVersion,
+	}
+	it := client.FetchProfiles(ctx, req)
+
+	var profiles []*gkerecommenderpb.Profile
+	for {
+		resp, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch next profile: %w", err)
+		}
+		profiles = append(profiles, resp)
+	}
+	return profiles, nil
+}
+
+// FetchProfiles fetches available profiles for GKE.
+func FetchProfiles(ctx context.Context, model, modelServer, modelServerVersion string) (string, error) {
+	// TODO: Add pagination support once profile list becomes very large to avoid memory risks.
+	profiles, err := fetchProfilesFunc(ctx, model, modelServer, modelServerVersion)
+	if err != nil {
+		return "", err
+	}
+	var output []string
+	for _, p := range profiles {
+		output = append(output, p.String())
+	}
+	return strings.Join(output, "\n---\n"), nil
+}

--- a/pkg/tools/giq/giq_test.go
+++ b/pkg/tools/giq/giq_test.go
@@ -16,7 +16,10 @@ package giq
 
 import (
 	"context"
+	"strings"
 	"testing"
+
+	gkerecommenderpb "cloud.google.com/go/gkerecommender/apiv1/gkerecommenderpb"
 )
 
 func TestGiqGenerateManifestArgs_Fields(t *testing.T) {
@@ -180,5 +183,30 @@ func TestFetchModelServers_Mock(t *testing.T) {
 	expected := "server-A\nserver-B"
 	if res != expected {
 		t.Errorf("FetchModelServers = %q, want %q", res, expected)
+	}
+}
+
+func TestFetchProfiles_Mock(t *testing.T) {
+	originalFunc := fetchProfilesFunc
+	defer func() { fetchProfilesFunc = originalFunc }()
+
+	fetchProfilesFunc = func(_ context.Context, model, modelServer, modelServerVersion string) ([]*gkerecommenderpb.Profile, error) {
+		if model != "test-model" {
+			t.Errorf("Expected model 'test-model', got %q", model)
+		}
+		return []*gkerecommenderpb.Profile{
+			{
+				AcceleratorType: "nvidia-l4",
+			},
+		}, nil
+	}
+
+	res, err := FetchProfiles(context.Background(), "test-model", "", "")
+	if err != nil {
+		t.Fatalf("FetchProfiles returned error: %v", err)
+	}
+
+	if !strings.Contains(res, "nvidia-l4") {
+		t.Errorf("Expected result to contain 'nvidia-l4', got %q", res)
 	}
 }

--- a/pkg/tools/giq/giq_test.go
+++ b/pkg/tools/giq/giq_test.go
@@ -194,6 +194,12 @@ func TestFetchProfiles_Mock(t *testing.T) {
 		if model != "test-model" {
 			t.Errorf("Expected model 'test-model', got %q", model)
 		}
+		if modelServer != "" {
+			t.Errorf("Expected empty modelServer, got %q", modelServer)
+		}
+		if modelServerVersion != "" {
+			t.Errorf("Expected empty modelServerVersion, got %q", modelServerVersion)
+		}
 		return []*gkerecommenderpb.Profile{
 			{
 				AcceleratorType: "nvidia-l4",


### PR DESCRIPTION
## 🎯 Why This Change?
This PR implements the `FetchProfiles` function in the `giq` package to call the GKE Recommender API SDK. This supports fetching available performance profiles for models and servers in GKE Inference Quickstart workflows.

## 📝 What Changed?
File: `pkg/tools/giq/giq.go`
- Added `FetchProfiles` function returning string representation of profiles.
- Added `fetchProfilesFunc` for mocking.

File: `pkg/tools/giq/giq_test.go`
- Added `TestFetchProfiles_Mock`.
- Added missing imports (`strings`, `gkerecommenderpb`).

## ✅ Testing
- Unit tests passed: `go test ./pkg/tools/giq/...`
- Full presubmit checks passed.

Ref #330