### PR TITLE
Fix: golangci-lint crash

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -110,7 +110,7 @@ jobs:
       - uses: ./.github/actions/build-ui
       - name: "Install golangci-lint"
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
+          curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin
       - name: "Run golangci-lint"
         run: |
           ./dev/ci/presubmits/golangci-lint.sh


### PR DESCRIPTION
### Summary
This PR updates the `golangci-lint` installation script URL in the presubmit workflow. It changes the source from the raw GitHub user content to the official `https://golangci-lint.run/install.sh`.

### Motivation
The CI pipeline was previously crashing during the `golangci-lint` installation step. By updating the curl command to use the official recommended installation endpoint, it resolves the installation failures (and checksum mismatches) and restores the CI build.
