### PR TITLE
feat(manifestgen): connect fetch model server versions tool to manifest agent

### DIFF
--- a/pkg/agents/manifestgen/manifestgen.go
+++ b/pkg/agents/manifestgen/manifestgen.go
@@ -50,6 +50,12 @@ type Agent struct {
 	sessionService session.Service
 }
 
+// FetchModelServerVersionsArgs holds arguments for fetching GIQ model server versions.
+type FetchModelServerVersionsArgs struct {
+	Model       string `json:"model" jsonschema:"The model for which to list model server versions. Required."`
+	ModelServer string `json:"model_server" jsonschema:"The model server for which to list versions. Required."`
+}
+
 // NewAgent creates a new Agent attached to a specific text generator model.
 func NewAgent(llm model.LLM, cfg *config.Config) (*Agent, error) {
 	if llm == nil {
@@ -84,12 +90,25 @@ func NewAgent(llm model.LLM, cfg *config.Config) (*Agent, error) {
 		return nil, fmt.Errorf("failed to create giq fetch models tool: %w", err)
 	}
 
+	fetchModelServerVersionsTool, err := functiontool.New(
+		functiontool.Config{
+			Name:        "fetch_model_server_versions",
+			Description: "Fetch available versions for a given model and model server in GKE Inference Quickstart (GIQ).",
+		},
+		func(ctx tool.Context, args FetchModelServerVersionsArgs) (string, error) {
+			return giq.FetchModelServerVersions(ctx, args.Model, args.ModelServer)
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create giq fetch model server versions tool: %w", err)
+	}
+
 	adkAgent, err := llmagent.New(llmagent.Config{
 		Name:        "manifest_agent",
 		Description: "Agent specialized in generating and validating Kubernetes manifests.",
 		Model:       llm,
 		Instruction: instructionTemplate,
-		Tools:       []tool.Tool{giqTool, fetchModelsTool},
+		Tools:       []tool.Tool{giqTool, fetchModelsTool, fetchModelServerVersionsTool},
 		BeforeModelCallbacks: []llmagent.BeforeModelCallback{
 			func(ctx agent.CallbackContext, llmRequest *model.LLMRequest) (*model.LLMResponse, error) {
 				// Inject user content if Contents is empty to avoid content loss.

--- a/pkg/agents/manifestgen/manifestgen.go
+++ b/pkg/agents/manifestgen/manifestgen.go
@@ -92,7 +92,7 @@ func NewAgent(llm model.LLM, cfg *config.Config) (*Agent, error) {
 
 	fetchModelServerVersionsTool, err := functiontool.New(
 		functiontool.Config{
-			Name:        "fetch_model_server_versions",
+			Name:        "giq_fetch_model_server_versions",
 			Description: "Fetch available versions for a given model and model server in GKE Inference Quickstart (GIQ).",
 		},
 		func(ctx tool.Context, args FetchModelServerVersionsArgs) (string, error) {

--- a/pkg/tools/giq/giq.go
+++ b/pkg/tools/giq/giq.go
@@ -196,3 +196,47 @@ func FetchProfiles(ctx context.Context, model, modelServer, modelServerVersion s
 	}
 	return strings.Join(output, "\n---\n"), nil
 }
+
+var fetchModelServerVersionsFunc = func(ctx context.Context, model, modelServer string) ([]string, error) {
+	client, err := gkerecommender.NewGkeInferenceQuickstartClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gkerecommender client: %w", err)
+	}
+	defer func() {
+		_ = client.Close()
+	}()
+
+	req := &gkerecommenderpb.FetchModelServerVersionsRequest{
+		Model:       model,
+		ModelServer: modelServer,
+	}
+	it := client.FetchModelServerVersions(ctx, req)
+
+	var versions []string
+	for {
+		resp, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch next model server version: %w", err)
+		}
+		versions = append(versions, resp)
+	}
+	return versions, nil
+}
+
+// FetchModelServerVersions fetches available model server versions for a given model and model server.
+func FetchModelServerVersions(ctx context.Context, model, modelServer string) (string, error) {
+	if model == "" {
+		return "", fmt.Errorf("model argument cannot be empty")
+	}
+	if modelServer == "" {
+		return "", fmt.Errorf("model_server argument cannot be empty")
+	}
+	versions, err := fetchModelServerVersionsFunc(ctx, model, modelServer)
+	if err != nil {
+		return "", err
+	}
+	return strings.Join(versions, "\n"), nil
+}

--- a/pkg/tools/giq/giq_test.go
+++ b/pkg/tools/giq/giq_test.go
@@ -216,3 +216,39 @@ func TestFetchProfiles_Mock(t *testing.T) {
 		t.Errorf("Expected result to contain 'nvidia-l4', got %q", res)
 	}
 }
+
+func TestFetchModelServerVersions_Mock(t *testing.T) {
+	originalFunc := fetchModelServerVersionsFunc
+	defer func() { fetchModelServerVersionsFunc = originalFunc }()
+
+	fetchModelServerVersionsFunc = func(_ context.Context, model, modelServer string) ([]string, error) {
+		if model != "test-model" {
+			t.Errorf("Expected model 'test-model', got %q", model)
+		}
+		if modelServer != "test-server" {
+			t.Errorf("Expected modelServer 'test-server', got %q", modelServer)
+		}
+		return []string{"v1", "v2"}, nil
+	}
+
+	res, err := FetchModelServerVersions(context.Background(), "test-model", "test-server")
+	if err != nil {
+		t.Fatalf("FetchModelServerVersions returned error: %v", err)
+	}
+
+	expected := "v1\nv2"
+	if res != expected {
+		t.Errorf("FetchModelServerVersions = %q, want %q", res, expected)
+	}
+}
+
+func TestFetchModelServerVersions_Validation(t *testing.T) {
+	_, err := FetchModelServerVersions(context.Background(), "", "server")
+	if err == nil {
+		t.Error("Expected error for empty model, got nil")
+	}
+	_, err = FetchModelServerVersions(context.Background(), "model", "")
+	if err == nil {
+		t.Error("Expected error for empty modelServer, got nil")
+	}
+}


### PR DESCRIPTION
## 🎯 Why This Change?
This PR connects the `giq_fetch_model_server_versions` tool to the `manifestgen` agent. This allows the agent to fetch available versions for a given model and model server, enabling better decision making and manifest generation.

As requested, this PR only includes the code change to connect the tool and does not modify the agent's instruction file.

## 📝 What Changed?
File: `pkg/agents/manifestgen/manifestgen.go`
- Defined `FetchModelServerVersionsArgs` struct for the tool arguments.
- Created `fetchModelServerVersionsTool` using `functiontool.New` which calls `giq.FetchModelServerVersions`.
- Added `fetchModelServerVersionsTool` to the agent's tool list in `NewAgent`.

## ✅ Testing
- Unit tests passed: `go test ./pkg/agents/manifestgen/...`
- Full presubmit checks passed successfully.

Ref #330
