### PR TITLE
Add review-assign workflow

### DIFF
--- a/.github/workflows/review-assign.yaml
+++ b/.github/workflows/review-assign.yaml
@@ -18,3 +18,5 @@ jobs:
           reviewers: ${{ vars.REVIEWERS }} # if draft, assigned when draft is released
           max-num-of-reviewers: 1
           draft-keyword: wip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/review-assign.yaml
+++ b/.github/workflows/review-assign.yaml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: hkusu/review-assign-action@v1
+        id: assign
         with:
           assignees: ${{ github.actor }} # assign pull request author
           reviewers: ${{ vars.REVIEWERS }} # if draft, assigned when draft is released
@@ -20,3 +21,6 @@ jobs:
           draft-keyword: wip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Show result
+        if: always()
+        run: echo '${{ steps.assign.outputs.result }}' # success or failure

--- a/.github/workflows/review-assign.yaml
+++ b/.github/workflows/review-assign.yaml
@@ -1,0 +1,20 @@
+name: Review Assign
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hkusu/review-assign-action@v1
+        with:
+          assignees: ${{ github.actor }} # assign pull request author
+          reviewers: ${{ vars.REVIEWERS }} # if draft, assigned when draft is released
+          max-num-of-reviewers: 1
+          draft-keyword: wip


### PR DESCRIPTION
# Add Review Assign Workflow

## Summary
This PR adds a new GitHub Action workflow `.github/workflows/review-assign.yaml` to automate the assignment of PRs and reviewers.

## Rationale
To streamline the code review process, this workflow automatically:
- Assigns the PR author as an assignee.
- Assigns reviewers based on the `REVIEWERS` repository variable.
- Limits the maximum number of reviewers to 1.
- Handles draft PRs and respects the 'wip' keyword.

Additionally, it defines explicit permissions (`pull-requests: write`, `contents: read`) to follow security best practices and satisfy linter requirements.

## Changes
- [NEW] `.github/workflows/review-assign.yaml`
