### PR TITLE
docs(manifestgen): add instructions for giq_fetch_model_server_versions

### DIFF
--- a/pkg/agents/manifestgen/instruction.md
+++ b/pkg/agents/manifestgen/instruction.md
@@ -364,6 +364,7 @@ fulfilled by one of the `gcloud container ai` commands listed below, you MUST
 use the corresponding MCP tool to accomplish the task.
 
 -   fetch_models: gcloud container ai profiles models list
+-   giq_fetch_model_server_versions: Find available versions for a given model and model server.
 -   giq_generate_manifest: gcloud container ai profiles manifests create
 
 GIQ provides estimates of expected performance based on benchmarks conducted on
@@ -384,6 +385,7 @@ model-as-a-service solutions.
     is useful for mapping from natural language (e.g., "Gemma 4") to an exact
     model name (e.g., "google/gemma-4-31B-it"). The workflow should always call
     `fetch_models` unless the user provides an exact model name.
+-   **To find valid versions for a specific model and model server:** Use `giq_fetch_model_server_versions`. You should use it if the user doesn't specify a version. It requires both `model` and `model_server` names as input.
 -   **To generate an optimized Kubernetes deployment manifest:** Use
     `giq_generate_manifest`. You MUST first call `fetch_profiles`
     to identify a valid configuration. From the chosen `Profile`, you MUST

--- a/pkg/agents/manifestgen/instruction.md
+++ b/pkg/agents/manifestgen/instruction.md
@@ -385,7 +385,7 @@ model-as-a-service solutions.
     is useful for mapping from natural language (e.g., "Gemma 4") to an exact
     model name (e.g., "google/gemma-4-31B-it"). The workflow should always call
     `fetch_models` unless the user provides an exact model name.
--   **To find valid versions for a specific model and model server:** Use `giq_fetch_model_server_versions`. You should use it if the user doesn't specify a version. It requires both `model` and `model_server` names as input.
+-   **To check available versions for a specific model and model server:** Use `giq_fetch_model_server_versions`. This tool requires both `model` and `model_server` names as input. It returns a list of supported versions. Use this tool to answer user questions about available versions or to validate a specific version request. Note that `giq_generate_manifest` does not accept a version parameter and will automatically use the recommended version for the selected model and server.
 -   **To generate an optimized Kubernetes deployment manifest:** Use
     `giq_generate_manifest`. You MUST first call `fetch_profiles`
     to identify a valid configuration. From the chosen `Profile`, you MUST


### PR DESCRIPTION
## 🎯 Why This Change?
This PR updates the agent's instructions in `instruction.md` to include guidance on how to use the `giq_fetch_model_server_versions` tool. This tool allows the agent to find available versions for a given model and model server in GKE Inference Quickstart workflows.

## 📝 What Changed?
File: `pkg/agents/manifestgen/instruction.md`
- Added `giq_fetch_model_server_versions` to the list of GIQ tools.
- Added a specific bullet point in the guidelines explaining when and how to use the tool.

## ✅ Testing
- N/A (Documentation change)

Ref #330
