### PR TITLE
fix: use npm install instead of npm ci for UI build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ build: build-ui ## Build the binary
 
 build-ui: ## Build the UI TypeScript code
 	@echo "Building UI..."
-	@npm --prefix $(UI_DIR) ci
+	@npm --prefix $(UI_DIR) install
 	@npm --prefix $(UI_DIR) run build
 	@echo "✓ UI built"
 

--- a/dev/tasks/update-ui.sh
+++ b/dev/tasks/update-ui.sh
@@ -20,5 +20,5 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "${REPO_ROOT}"
 
-npm --prefix ui ci
+npm --prefix ui install
 npm --prefix ui run build


### PR DESCRIPTION
# 🎯 Why This Change?

This PR changes the UI build process to use `npm install` instead of `npm ci` in the `Makefile` and `update-ui.sh` script.
This allows local development to update `package-lock.json` when dependencies change, which is not possible with `npm ci`. `npm ci` is strictly for installing from an existing lockfile and will fail if the lockfile is out of sync with `package.json`.

# 📝 What Changed?

## `Makefile`
Changed `npm --prefix $(UI_DIR) ci` to `npm --prefix $(UI_DIR) install` in the `build-ui` target.

## `dev/tasks/update-ui.sh`
Changed `npm --prefix ui ci` to `npm --prefix ui install`.

# ✅ Why This Matters

### 1. **Eases Local Development**
   - Developers can now add or update UI dependencies and build the UI without manually running `npm install` first to update the lockfile.

### 2. **Flexibility**
   - `npm install` is more suitable for a developer's machine where active changes might be happening.

# ✅ Testing

I have run the presubmit checks `./dev/tasks/presubmit.sh` and verified they pass.
