### PR TITLE
chore: remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,0 @@
-# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
-
-# Order is important; the last matching pattern takes the most precedence.
-
-# These owners will be the default owners for everything in the repo.
-*       @GoogleCloudPlatform/gke-mcp-approvers
-


### PR DESCRIPTION
## Summary
- remove the repository CODEOWNERS file

## Notes
- branch pushed to `bradhoekstra/gke-mcp` per local preference

## Validation
- file removal only