### PR TITLE
docs: add AI agent instructions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,10 +30,12 @@
 ## Testing
 
 ```bash
+./dev/tasks/presubmit.sh  # Pass
 # List the relevant checks you ran and their results.
 ```
 
-<!-- If checks were not run, explain why. -->
+<!-- Run ./dev/tasks/presubmit.sh locally before creating the PR. If it could
+not be run or did not pass, explain why. -->
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,10 @@
-## Why This Change?
+# Pull Request
+
+## Why This Change
 
 <!-- Explain the problem, motivation, or user need this PR addresses. -->
 
-## What Changed?
+## What Changed
 
 <!-- Summarize the important files, behavior, or workflow changes. -->
 
@@ -16,15 +18,15 @@
 
 ## Why This Matters
 
-### 1.
+### 1
 
 -
 
-### 2.
+### 2
 
 -
 
-### 3.
+### 3
 
 -
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+## Why This Change?
+
+<!-- Explain the problem, motivation, or user need this PR addresses. -->
+
+## What Changed?
+
+<!-- Summarize the important files, behavior, or workflow changes. -->
+
+**Files:**
+- `path/to/file`
+
+**Added/Changed/Fixed:**
+- 
+
+## Why This Matters
+
+### 1. 
+- 
+
+### 2. 
+- 
+
+### 3. 
+- 
+
+## Context
+
+<!-- Include related issues, PRs, follow-up work, or other background. -->
+
+## Testing
+
+```bash
+# List the relevant checks you ran and their results.
+```
+
+<!-- If checks were not run, explain why. -->
+
+---
+
+<!-- Close with a short note on functional impact, risk, or rollout. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,8 +34,9 @@
 # List the relevant checks you ran and their results.
 ```
 
-<!-- Run ./dev/tasks/presubmit.sh locally before creating the PR. If it could
-not be run or did not pass, explain why. -->
+<!-- Run ./dev/tasks/presubmit.sh locally before creating the PR. It can take
+several minutes, so run it as a background or otherwise non-blocking task when
+possible. If it could not be run or did not pass, explain why. -->
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,21 +7,26 @@
 <!-- Summarize the important files, behavior, or workflow changes. -->
 
 **Files:**
+
 - `path/to/file`
 
 **Added/Changed/Fixed:**
-- 
+
+-
 
 ## Why This Matters
 
-### 1. 
-- 
+### 1.
 
-### 2. 
-- 
+-
 
-### 3. 
-- 
+### 2.
+
+-
+
+### 3.
+
+-
 
 ## Context
 
@@ -36,7 +41,9 @@
 
 <!-- Run ./dev/tasks/presubmit.sh locally before creating the PR. It can take
 several minutes, so run it as a background or otherwise non-blocking task when
-possible. If it could not be run or did not pass, explain why. -->
+possible. If this PR updates Markdown files, run npx prettier --write on those
+files before committing. If presubmit could not be run or did not pass, explain
+why. -->
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,93 @@
+# AGENTS.md
+
+## Project Overview
+
+This repository contains the GKE MCP server and Gemini CLI extension. The main
+server is written in Go. Web UI assets live under `ui/` and are built into
+checked-in single-file HTML bundles under `ui/dist/apps/`. Reusable AI skills
+live under `skills/`, each with its own `SKILL.md`.
+
+## Repository Layout
+
+- `cmd/`, `pkg/`: Go source for the MCP server, tools, config, and agents.
+- `ui/`: Vite/React TypeScript apps and shared UI code.
+- `ui/apps/*/index.html`: source app HTML entrypoints.
+- `ui/dist/apps/*/index.html`: generated, checked-in UI bundles embedded by Go.
+- `skills/*/SKILL.md`: Gemini/Codex skill definitions and instructions.
+- `dev/tasks/`: local maintenance tasks that may update files.
+- `dev/ci/presubmits/`: CI-equivalent verification scripts.
+
+## Development Commands
+
+- Build everything: `make build`
+- Build Go only: `go build -v ./...`
+- Run Go tests: `go test -v ./...`
+- Run Go vet: `go vet ./...`
+- Install UI dependencies: `npm --prefix ui install`
+- Build UI bundles: `npm --prefix ui run build`
+- Run UI tests: `npm --prefix ui run test`
+- Run UI lint: `npm --prefix ui run lint`
+- Format all supported files: `./dev/tasks/format.sh`
+- Run local presubmit: `make presubmit`
+
+Run the smallest relevant check for the files you changed. For broad changes,
+prefer `make presubmit` when feasible.
+
+## Generated Files
+
+The files under `ui/dist/apps/` are generated but checked in because Go embeds
+them. Do not edit them by hand. Change source files under `ui/apps/`,
+`ui/shared/`, or UI build configuration, then regenerate with:
+
+```sh
+npm --prefix ui run build
+```
+
+To verify generated UI bundles are current, run:
+
+```sh
+./dev/ci/presubmits/verify-ui.sh
+```
+
+If `verify-ui.sh` reports changes after an intentional UI update, include the
+updated `ui/dist/apps/*/index.html` files in the same change.
+
+## Go Guidelines
+
+- Keep Go code formatted with `gofmt`.
+- If dependencies change, run `go mod tidy` or `./dev/tasks/gomod.sh`.
+- Add or update focused tests near changed behavior.
+- Prefer existing package patterns in `pkg/tools`, `pkg/config`, and
+  `pkg/agents` before adding new abstractions.
+
+## UI Guidelines
+
+- The UI uses Vite, React, TypeScript, MUI, and Vitest.
+- Keep source changes in `ui/apps/` or `ui/shared/` when possible.
+- Run `npm --prefix ui run lint` after TypeScript or React changes.
+- Run `npm --prefix ui run test` for UI logic changes.
+- Regenerate `ui/dist` after UI source or build configuration changes.
+
+## Skills Guidelines
+
+- Each directory under `skills/` must contain a `SKILL.md`.
+- `SKILL.md` files must start with frontmatter containing non-empty `name` and
+  `description` fields.
+- The frontmatter `name` must match the skill directory name.
+- Validate skills with:
+
+```sh
+./dev/ci/presubmits/validate-skills.sh
+```
+
+## Pull Request Hygiene
+
+- Keep changes scoped to the request.
+- Do not commit unrelated formatting or generated output.
+- Use Conventional Commits for commit messages.
+- Push PR branches to a fork, not to the upstream repository.
+- Use https://github.com/GoogleCloudPlatform/gke-mcp/pull/153 as a good
+  example for PR body structure and level of detail.
+- Mention any checks that could not be run and why.
+- For generated bundle changes, explain which source or build configuration
+  change caused the regenerated output.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ live under `skills/`, each with its own `SKILL.md`.
 - Run UI tests: `npm --prefix ui run test`
 - Run UI lint: `npm --prefix ui run lint`
 - Format all supported files: `./dev/tasks/format.sh`
-- Run local presubmit: `make presubmit`
+- Run local presubmit: `./dev/tasks/presubmit.sh` or `make presubmit`
 
 Run the smallest relevant check for the files you changed. For broad changes,
 prefer `make presubmit` when feasible.
@@ -88,6 +88,8 @@ updated `ui/dist/apps/*/index.html` files in the same change.
 - Push PR branches to a fork, not to the upstream repository.
 - Use `.github/PULL_REQUEST_TEMPLATE.md` for PR body structure and level of
   detail.
+- Run `./dev/tasks/presubmit.sh` locally before creating a PR, and only create
+  the PR once presubmit passes.
 - Mention any checks that could not be run and why.
 - For generated bundle changes, explain which source or build configuration
   change caused the regenerated output.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,9 @@ updated `ui/dist/apps/*/index.html` files in the same change.
   detail.
 - Run `./dev/tasks/presubmit.sh` locally before creating a PR, and only create
   the PR once presubmit passes.
+- The presubmit script can take several minutes; when tooling supports it, run
+  it as a background or otherwise non-blocking task while continuing other PR
+  preparation.
 - Mention any checks that could not be run and why.
 - For generated bundle changes, explain which source or build configuration
   change caused the regenerated output.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,8 +86,8 @@ updated `ui/dist/apps/*/index.html` files in the same change.
 - Do not commit unrelated formatting or generated output.
 - Use Conventional Commits for commit messages.
 - Push PR branches to a fork, not to the upstream repository.
-- Use https://github.com/GoogleCloudPlatform/gke-mcp/pull/153 as a good
-  example for PR body structure and level of detail.
+- Use `.github/PULL_REQUEST_TEMPLATE.md` for PR body structure and level of
+  detail.
 - Mention any checks that could not be run and why.
 - For generated bundle changes, explain which source or build configuration
   change caused the regenerated output.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ live under `skills/`, each with its own `SKILL.md`.
 - Run UI tests: `npm --prefix ui run test`
 - Run UI lint: `npm --prefix ui run lint`
 - Format all supported files: `./dev/tasks/format.sh`
+- Format Markdown files after editing: `npx prettier --write <files>`
 - Run local presubmit: `./dev/tasks/presubmit.sh` or `make presubmit`
 
 Run the smallest relevant check for the files you changed. For broad changes,
@@ -88,6 +89,8 @@ updated `ui/dist/apps/*/index.html` files in the same change.
 - Push PR branches to a fork, not to the upstream repository.
 - Use `.github/PULL_REQUEST_TEMPLATE.md` for PR body structure and level of
   detail.
+- When updating Markdown files, run `npx prettier --write <files>` on the
+  changed Markdown files before committing.
 - Run `./dev/tasks/presubmit.sh` locally before creating a PR, and only create
   the PR once presubmit passes.
 - The presubmit script can take several minutes; when tooling supports it, run

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,3 @@
 # CLAUDE.md: AI Instructions for Claude Code
 
 @./AGENTS.md
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+# CLAUDE.md: AI Instructions for Claude Code
+
+@./AGENTS.md
+


### PR DESCRIPTION
## Why This Change?

This PR adds repository-level instructions for AI coding agents and a local pull request template so agents and contributors can follow the project layout, generated file workflow, validation commands, and PR hygiene expected in this repository without relying on an external example PR.

## What Changed?

**Files:**
- `AGENTS.md`
- `CLAUDE.md`
- `.github/PULL_REQUEST_TEMPLATE.md`

**Added:** Repository guidance covering project structure, development commands, generated UI bundle handling, Go/UI/skills conventions, Markdown formatting, and PR expectations.

**Added:** A pull request template based on the structure and level of detail from the existing example PR.

**Changed:** `AGENTS.md` now points to `.github/PULL_REQUEST_TEMPLATE.md` for PR body structure instead of referencing PR #153 directly.

**Changed:** `AGENTS.md` and the PR template now instruct contributors to run `./dev/tasks/presubmit.sh` locally before creating PRs, and to only create PRs once presubmit passes.

**Changed:** Presubmit guidance now notes that the script can take several minutes and should be run as a background or otherwise non-blocking task when tooling supports it.

**Changed:** Markdown guidance now instructs contributors to run `npx prettier --write <files>` when updating Markdown files.

**Compatibility:** `CLAUDE.md` delegates to `AGENTS.md` so Claude Code can use the same shared instructions.

## Why This Matters

### 1. Consistent Agent Behavior
- Gives AI agents a single source of truth for local workflows and repository expectations
- Reduces the chance of agents editing generated files directly or running overly broad checks unnecessarily

### 2. Clear Development Guidance
- Documents the smallest relevant verification commands for Go, UI, generated bundles, skills, and Markdown files
- Points agents toward existing package and UI patterns before adding new abstractions

### 3. Better PR Hygiene
- Provides a reusable local PR template with the expected sections and level of detail
- Requires local presubmit to pass before PR creation while encouraging non-blocking execution when possible
- Captures project expectations around scoped changes, generated bundle explanations, Markdown formatting, and Conventional Commit messages
- Directs PR branches to forks instead of the upstream repository

## Context

This is a documentation-only change intended to improve future AI-assisted contributions to the repository.

## Testing

```bash
npx prettier --write AGENTS.md CLAUDE.md .github/PULL_REQUEST_TEMPLATE.md  # Failed: sandbox could not resolve registry.npmjs.org
ui/node_modules/.bin/prettier --write AGENTS.md CLAUDE.md .github/PULL_REQUEST_TEMPLATE.md  # Pass
./dev/tasks/presubmit.sh  # Failed in ./dev/ci/presubmits/docker-build.sh: Docker build hit ENOSPC (no space left on device) while running go mod download inside the build image.
```

The presubmit run passed `gomod`, `update-ui`, `format`, `ui-test`, `go-build`, `go-test`, and `go-vet` before failing during the Docker build stage because the local environment ran out of disk space.

---

This is a pure documentation change with no functional impact.