### PR TITLE
feat(k8s): implement list_k8s_events tool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	google.golang.org/genai v1.56.0
 	google.golang.org/genproto v0.0.0-20260414002931-afd174a4e478
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
+	k8s.io/api v0.36.0
 	k8s.io/apimachinery v0.36.0
 	k8s.io/client-go v0.36.0
 	sigs.k8s.io/yaml v1.6.0
@@ -92,9 +93,9 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4 // indirect
 	google.golang.org/grpc v1.80.0 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.36.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260414162039-ec9c827d403f // indirect
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect

--- a/pkg/tools/k8s/client.go
+++ b/pkg/tools/k8s/client.go
@@ -22,9 +22,19 @@ import (
 
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
+
+// Provider defines the interface for providing Kubernetes clients.
+type Provider interface {
+	RESTConfig(ctx context.Context, clusterPath string) (*rest.Config, error)
+	DynamicClient(ctx context.Context, clusterPath string) (dynamic.Interface, error)
+	DynamicClientWithHeaders(ctx context.Context, clusterPath string, headerName, headerValue string) (dynamic.Interface, error)
+	DiscoveryClient(ctx context.Context, clusterPath string) (discovery.DiscoveryInterface, error)
+	KubernetesClient(ctx context.Context, clusterPath string) (kubernetes.Interface, error)
+}
 
 // ClientProvider provides Kubernetes clients for a GKE cluster.
 type ClientProvider struct {
@@ -88,6 +98,15 @@ func (p *ClientProvider) DiscoveryClient(ctx context.Context, clusterPath string
 		return nil, err
 	}
 	return discovery.NewDiscoveryClientForConfig(config)
+}
+
+// KubernetesClient returns a kubernetes.Interface for the given cluster.
+func (p *ClientProvider) KubernetesClient(ctx context.Context, clusterPath string) (kubernetes.Interface, error) {
+	config, err := p.RESTConfig(ctx, clusterPath)
+	if err != nil {
+		return nil, err
+	}
+	return kubernetes.NewForConfig(config)
 }
 
 // HeaderRoundTripper is an http.RoundTripper that adds a specific header to each request.

--- a/pkg/tools/k8s/discovery.go
+++ b/pkg/tools/k8s/discovery.go
@@ -24,10 +24,10 @@ import (
 )
 
 // ResolveGVR resolves a resource kind or name (e.g., "pods", "deployments") to its GroupVersionResource.
-func ResolveGVR(_ context.Context, discoveryClient discovery.DiscoveryInterface, resource string) (schema.GroupVersionResource, bool, error) {
+func ResolveGVR(_ context.Context, discoveryClient discovery.DiscoveryInterface, resource string) (schema.GroupVersionResource, schema.GroupVersionKind, bool, error) {
 	groupResources, err := restmapper.GetAPIGroupResources(discoveryClient)
 	if err != nil {
-		return schema.GroupVersionResource{}, false, fmt.Errorf("failed to get API group resources: %w", err)
+		return schema.GroupVersionResource{}, schema.GroupVersionKind{}, false, fmt.Errorf("failed to get API group resources: %w", err)
 	}
 
 	mapper := restmapper.NewDiscoveryRESTMapper(groupResources)
@@ -37,13 +37,13 @@ func ResolveGVR(_ context.Context, discoveryClient discovery.DiscoveryInterface,
 	if err == nil {
 		gvk, err := mapper.KindFor(gvr)
 		if err != nil {
-			return gvr, false, err
+			return gvr, schema.GroupVersionKind{}, false, err
 		}
 		mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 		if err != nil {
-			return gvr, false, err
+			return gvr, schema.GroupVersionKind{}, false, err
 		}
-		return gvr, mapping.Scope.Name() == "namespace", nil
+		return gvr, gvk, mapping.Scope.Name() == "namespace", nil
 	}
 
 	// Then try to resolve as a kind (e.g., "Pod")
@@ -51,10 +51,10 @@ func ResolveGVR(_ context.Context, discoveryClient discovery.DiscoveryInterface,
 	if err == nil {
 		mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 		if err != nil {
-			return schema.GroupVersionResource{}, false, err
+			return schema.GroupVersionResource{}, schema.GroupVersionKind{}, false, err
 		}
-		return mapping.Resource, mapping.Scope.Name() == "namespace", nil
+		return mapping.Resource, gvk, mapping.Scope.Name() == "namespace", nil
 	}
 
-	return schema.GroupVersionResource{}, false, fmt.Errorf("failed to resolve resource %q: %w", resource, err)
+	return schema.GroupVersionResource{}, schema.GroupVersionKind{}, false, fmt.Errorf("failed to resolve resource %q: %w", resource, err)
 }

--- a/pkg/tools/k8s/events.go
+++ b/pkg/tools/k8s/events.go
@@ -65,7 +65,9 @@ func (h *handlers) listK8SEvents(ctx context.Context, _ *mcp.CallToolRequest, ar
 	}
 
 	namespace := args.Namespace
-	if !args.AllNamespaces && namespace == "" {
+	if args.AllNamespaces {
+		namespace = ""
+	} else if namespace == "" {
 		namespace = "default"
 	}
 

--- a/pkg/tools/k8s/events.go
+++ b/pkg/tools/k8s/events.go
@@ -122,15 +122,15 @@ func (h *handlers) listK8SEvents(ctx context.Context, _ *mcp.CallToolRequest, ar
 	w := tabwriter.NewWriter(&buf, 0, 0, 3, ' ', 0)
 
 	if args.AllNamespaces {
-		fmt.Fprintf(w, "NAMESPACE\t")
+		_, _ = fmt.Fprintf(w, "NAMESPACE\t")
 	}
-	fmt.Fprintf(w, "LAST SEEN\tTYPE\tREASON\tOBJECT\tMESSAGE\n")
+	_, _ = fmt.Fprintf(w, "LAST SEEN\tTYPE\tREASON\tOBJECT\tMESSAGE\n")
 
 	for _, event := range eventList.Items {
 		if args.AllNamespaces {
-			fmt.Fprintf(w, "%s\t", event.InvolvedObject.Namespace)
+			_, _ = fmt.Fprintf(w, "%s\t", event.InvolvedObject.Namespace)
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s/%s\t%s\n",
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s/%s\t%s\n",
 			getInterval(event),
 			event.Type,
 			event.Reason,
@@ -139,7 +139,7 @@ func (h *handlers) listK8SEvents(ctx context.Context, _ *mcp.CallToolRequest, ar
 			event.Message,
 		)
 	}
-	w.Flush()
+	_ = w.Flush()
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{

--- a/pkg/tools/k8s/events.go
+++ b/pkg/tools/k8s/events.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -26,10 +27,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/duration"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/restmapper"
 )
 
 type listK8SEventsArgs struct {
@@ -44,14 +42,9 @@ type listK8SEventsArgs struct {
 func (h *handlers) listK8SEvents(ctx context.Context, _ *mcp.CallToolRequest, args *listK8SEventsArgs) (*mcp.CallToolResult, any, error) {
 	clusterPath := args.ClusterPath()
 
-	config, err := h.provider.RESTConfig(ctx, clusterPath)
+	clientset, err := h.provider.KubernetesClient(ctx, clusterPath)
 	if err != nil {
-		return params.ErrorResult(fmt.Errorf("failed to get rest config: %w", err)), nil, nil
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return params.ErrorResult(fmt.Errorf("failed to create clientset: %w", err)), nil, nil
+		return params.ErrorResult(fmt.Errorf("failed to get kubernetes client: %w", err)), nil, nil
 	}
 
 	apiVersion := ""
@@ -62,26 +55,9 @@ func (h *handlers) listK8SEvents(ctx context.Context, _ *mcp.CallToolRequest, ar
 			return params.ErrorResult(fmt.Errorf("failed to get discovery client: %w", err)), nil, nil
 		}
 
-		groupResources, err := restmapper.GetAPIGroupResources(discoveryClient)
+		_, gvk, _, err := ResolveGVR(ctx, discoveryClient, args.ResourceType)
 		if err != nil {
-			return params.ErrorResult(fmt.Errorf("failed to get API group resources: %w", err)), nil, nil
-		}
-		mapper := restmapper.NewDiscoveryRESTMapper(groupResources)
-
-		// Try to resolve as a direct resource name (e.g., "pods")
-		gvr, err := mapper.ResourceFor(schema.GroupVersionResource{Resource: args.ResourceType})
-		var gvk schema.GroupVersionKind
-		if err == nil {
-			gvk, err = mapper.KindFor(gvr)
-			if err != nil {
-				return params.ErrorResult(fmt.Errorf("failed to get kind for resource: %w", err)), nil, nil
-			}
-		} else {
-			// Then try to resolve as a kind (e.g., "Pod")
-			gvk, err = mapper.KindFor(schema.GroupVersionResource{Resource: args.ResourceType})
-			if err != nil {
-				return params.ErrorResult(fmt.Errorf("failed to resolve resource type %q: %w", args.ResourceType, err)), nil, nil
-			}
+			return params.ErrorResult(err), nil, nil
 		}
 
 		kind = gvk.Kind
@@ -98,17 +74,20 @@ func (h *handlers) listK8SEvents(ctx context.Context, _ *mcp.CallToolRequest, ar
 		limit = 500
 	}
 
-	selector := ""
+	var selectorParts []string
 	if !args.AllNamespaces {
-		selector = fmt.Sprintf("involvedObject.namespace=%s,", namespace)
+		selectorParts = append(selectorParts, fmt.Sprintf("involvedObject.namespace=%s", namespace))
 	}
 	if kind != "" {
-		selector = selector + fmt.Sprintf("involvedObject.kind=%s,involvedObject.name=%s", kind, args.Name)
-		if apiVersion != "" {
-			selector = selector + fmt.Sprintf(",involvedObject.apiVersion=%s", apiVersion)
-		}
+		selectorParts = append(selectorParts, fmt.Sprintf("involvedObject.kind=%s", kind))
 	}
-	selector = strings.TrimSuffix(selector, ",")
+	if args.Name != "" {
+		selectorParts = append(selectorParts, fmt.Sprintf("involvedObject.name=%s", args.Name))
+	}
+	if apiVersion != "" {
+		selectorParts = append(selectorParts, fmt.Sprintf("involvedObject.apiVersion=%s", apiVersion))
+	}
+	selector := strings.Join(selectorParts, ",")
 
 	eventList, err := clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{
 		Limit:         limit,
@@ -117,6 +96,10 @@ func (h *handlers) listK8SEvents(ctx context.Context, _ *mcp.CallToolRequest, ar
 	if err != nil {
 		return params.ErrorResult(fmt.Errorf("failed to list events: %w", err)), nil, nil
 	}
+
+	sort.Slice(eventList.Items, func(i, j int) bool {
+		return getLastSeenTime(eventList.Items[i]).After(getLastSeenTime(eventList.Items[j]))
+	})
 
 	var buf bytes.Buffer
 	w := tabwriter.NewWriter(&buf, 0, 0, 3, ' ', 0)
@@ -176,4 +159,17 @@ func translateTimestampSince(timestamp metav1.Time) string {
 		return "<unknown>"
 	}
 	return duration.HumanDuration(time.Since(timestamp.Time))
+}
+
+func getLastSeenTime(e corev1.Event) time.Time {
+	if e.Series != nil && !e.Series.LastObservedTime.IsZero() {
+		return e.Series.LastObservedTime.Time
+	}
+	if !e.LastTimestamp.IsZero() {
+		return e.LastTimestamp.Time
+	}
+	if !e.EventTime.IsZero() {
+		return e.EventTime.Time
+	}
+	return e.FirstTimestamp.Time
 }

--- a/pkg/tools/k8s/events.go
+++ b/pkg/tools/k8s/events.go
@@ -103,6 +103,7 @@ func (h *handlers) listK8SEvents(ctx context.Context, _ *mcp.CallToolRequest, ar
 		return getLastSeenTime(eventList.Items[i]).After(getLastSeenTime(eventList.Items[j]))
 	})
 
+	replacer := strings.NewReplacer("\n", " ", "\t", " ")
 	var buf bytes.Buffer
 	w := tabwriter.NewWriter(&buf, 0, 0, 3, ' ', 0)
 
@@ -121,7 +122,7 @@ func (h *handlers) listK8SEvents(ctx context.Context, _ *mcp.CallToolRequest, ar
 			event.Reason,
 			event.InvolvedObject.Kind,
 			event.InvolvedObject.Name,
-			event.Message,
+			replacer.Replace(event.Message),
 		)
 	}
 	_ = w.Flush()

--- a/pkg/tools/k8s/events.go
+++ b/pkg/tools/k8s/events.go
@@ -1,0 +1,179 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/params"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/duration"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/restmapper"
+)
+
+type listK8SEventsArgs struct {
+	params.Cluster
+	Name          string `json:"name,omitempty" jsonschema:"Optional. The name of the resource to retrieve events for."`
+	Namespace     string `json:"namespace,omitempty" jsonschema:"Optional. The namespace of the resource. If not specified and allNamespaces is false, 'default' is used."`
+	ResourceType  string `json:"resourceType,omitempty" jsonschema:"Optional. The type of the resource to retrieve events for."`
+	AllNamespaces bool   `json:"allNamespaces,omitempty" jsonschema:"Optional. If true, retrieve events from all namespaces."`
+	Limit         int64  `json:"limit,omitempty" jsonschema:"Optional. The maximum number of events to return. If not specified, 500 is used."`
+}
+
+func (h *handlers) listK8SEvents(ctx context.Context, _ *mcp.CallToolRequest, args *listK8SEventsArgs) (*mcp.CallToolResult, any, error) {
+	clusterPath := args.ClusterPath()
+
+	config, err := h.provider.RESTConfig(ctx, clusterPath)
+	if err != nil {
+		return params.ErrorResult(fmt.Errorf("failed to get rest config: %w", err)), nil, nil
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return params.ErrorResult(fmt.Errorf("failed to create clientset: %w", err)), nil, nil
+	}
+
+	apiVersion := ""
+	kind := ""
+	if args.ResourceType != "" {
+		discoveryClient, err := h.provider.DiscoveryClient(ctx, clusterPath)
+		if err != nil {
+			return params.ErrorResult(fmt.Errorf("failed to get discovery client: %w", err)), nil, nil
+		}
+
+		groupResources, err := restmapper.GetAPIGroupResources(discoveryClient)
+		if err != nil {
+			return params.ErrorResult(fmt.Errorf("failed to get API group resources: %w", err)), nil, nil
+		}
+		mapper := restmapper.NewDiscoveryRESTMapper(groupResources)
+
+		// Try to resolve as a direct resource name (e.g., "pods")
+		gvr, err := mapper.ResourceFor(schema.GroupVersionResource{Resource: args.ResourceType})
+		var gvk schema.GroupVersionKind
+		if err == nil {
+			gvk, err = mapper.KindFor(gvr)
+			if err != nil {
+				return params.ErrorResult(fmt.Errorf("failed to get kind for resource: %w", err)), nil, nil
+			}
+		} else {
+			// Then try to resolve as a kind (e.g., "Pod")
+			gvk, err = mapper.KindFor(schema.GroupVersionResource{Resource: args.ResourceType})
+			if err != nil {
+				return params.ErrorResult(fmt.Errorf("failed to resolve resource type %q: %w", args.ResourceType, err)), nil, nil
+			}
+		}
+
+		kind = gvk.Kind
+		apiVersion = gvk.GroupVersion().String()
+	}
+
+	namespace := args.Namespace
+	if !args.AllNamespaces && namespace == "" {
+		namespace = "default"
+	}
+
+	limit := args.Limit
+	if limit <= 0 {
+		limit = 500
+	}
+
+	selector := ""
+	if !args.AllNamespaces {
+		selector = fmt.Sprintf("involvedObject.namespace=%s,", namespace)
+	}
+	if kind != "" {
+		selector = selector + fmt.Sprintf("involvedObject.kind=%s,involvedObject.name=%s", kind, args.Name)
+		if apiVersion != "" {
+			selector = selector + fmt.Sprintf(",involvedObject.apiVersion=%s", apiVersion)
+		}
+	}
+	selector = strings.TrimSuffix(selector, ",")
+
+	eventList, err := clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{
+		Limit:         limit,
+		FieldSelector: selector,
+	})
+	if err != nil {
+		return params.ErrorResult(fmt.Errorf("failed to list events: %w", err)), nil, nil
+	}
+
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, 0, 0, 3, ' ', 0)
+	
+	if args.AllNamespaces {
+		fmt.Fprintf(w, "NAMESPACE\t")
+	}
+	fmt.Fprintf(w, "LAST SEEN\tTYPE\tREASON\tOBJECT\tMESSAGE\n")
+
+	for _, event := range eventList.Items {
+		if args.AllNamespaces {
+			fmt.Fprintf(w, "%s\t", event.InvolvedObject.Namespace)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s/%s\t%s\n",
+			getInterval(event),
+			event.Type,
+			event.Reason,
+			event.InvolvedObject.Kind,
+			event.InvolvedObject.Name,
+			event.Message,
+		)
+	}
+	w.Flush()
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: buf.String()},
+		},
+	}, nil, nil
+}
+
+func getInterval(e corev1.Event) string {
+	var interval string
+	firstTimestampSince := translateMicroTimestampSince(e.EventTime)
+	if e.EventTime.IsZero() {
+		firstTimestampSince = translateTimestampSince(e.FirstTimestamp)
+	}
+	if e.Series != nil {
+		interval = fmt.Sprintf("%s (x%d over %s)", translateMicroTimestampSince(e.Series.LastObservedTime), e.Series.Count, firstTimestampSince)
+	} else if e.Count > 1 {
+		interval = fmt.Sprintf("%s (x%d over %s)", translateTimestampSince(e.LastTimestamp), e.Count, firstTimestampSince)
+	} else {
+		interval = firstTimestampSince
+	}
+	return interval
+}
+
+func translateMicroTimestampSince(timestamp metav1.MicroTime) string {
+	if timestamp.IsZero() {
+		return "<unknown>"
+	}
+	return duration.HumanDuration(time.Since(timestamp.Time))
+}
+
+func translateTimestampSince(timestamp metav1.Time) string {
+	if timestamp.IsZero() {
+		return "<unknown>"
+	}
+	return duration.HumanDuration(time.Since(timestamp.Time))
+}

--- a/pkg/tools/k8s/events.go
+++ b/pkg/tools/k8s/events.go
@@ -120,7 +120,7 @@ func (h *handlers) listK8SEvents(ctx context.Context, _ *mcp.CallToolRequest, ar
 
 	var buf bytes.Buffer
 	w := tabwriter.NewWriter(&buf, 0, 0, 3, ' ', 0)
-	
+
 	if args.AllNamespaces {
 		fmt.Fprintf(w, "NAMESPACE\t")
 	}

--- a/pkg/tools/k8s/events_test.go
+++ b/pkg/tools/k8s/events_test.go
@@ -227,3 +227,43 @@ func TestListK8SEvents_WithResourceType(t *testing.T) {
 		t.Fatalf("listK8SEvents returned error result: %v", result.Content[0])
 	}
 }
+
+func TestListK8SEvents_AllNamespacesOverridesNamespace(t *testing.T) {
+	ctx := context.Background()
+
+	fakeClientset := fake.NewSimpleClientset()
+
+	mockProvider := &mockClientProvider{
+		kubernetesClient: fakeClientset,
+	}
+
+	h := &handlers{
+		c:        &config.Config{},
+		provider: mockProvider,
+	}
+
+	args := &listK8SEventsArgs{
+		Namespace:     "some-namespace",
+		AllNamespaces: true,
+	}
+	args.ProjectID = "p"
+	args.Location = "l"
+	args.ClusterName = "c"
+
+	_, _, err := h.listK8SEvents(ctx, &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatalf("listK8SEvents failed: %v", err)
+	}
+
+	actions := fakeClientset.Actions()
+	if len(actions) < 1 {
+		t.Fatalf("expected at least 1 action, got %d", len(actions))
+	}
+	action := actions[0]
+	if action.GetVerb() != "list" {
+		t.Errorf("expected list action, got %s", action.GetVerb())
+	}
+	if action.GetNamespace() != "" {
+		t.Errorf("expected all namespaces (empty string), got %s", action.GetNamespace())
+	}
+}

--- a/pkg/tools/k8s/events_test.go
+++ b/pkg/tools/k8s/events_test.go
@@ -15,8 +15,50 @@
 package k8s
 
 import (
+	"context"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
 )
+
+type mockClientProvider struct {
+	restConfig       *rest.Config
+	dynamicClient    dynamic.Interface
+	discoveryClient  discovery.DiscoveryInterface
+	kubernetesClient kubernetes.Interface
+	err              error
+}
+
+func (m *mockClientProvider) RESTConfig(_ context.Context, _ string) (*rest.Config, error) {
+	return m.restConfig, m.err
+}
+
+func (m *mockClientProvider) DynamicClient(_ context.Context, _ string) (dynamic.Interface, error) {
+	return m.dynamicClient, m.err
+}
+
+func (m *mockClientProvider) DynamicClientWithHeaders(_ context.Context, _ string, _, _ string) (dynamic.Interface, error) {
+	return m.dynamicClient, m.err
+}
+
+func (m *mockClientProvider) DiscoveryClient(_ context.Context, _ string) (discovery.DiscoveryInterface, error) {
+	return m.discoveryClient, m.err
+}
+
+func (m *mockClientProvider) KubernetesClient(_ context.Context, _ string) (kubernetes.Interface, error) {
+	return m.kubernetesClient, m.err
+}
 
 func TestListK8SEventsArgs_Fields(t *testing.T) {
 	args := listK8SEventsArgs{
@@ -47,5 +89,141 @@ func TestListK8SEventsArgs_Fields(t *testing.T) {
 	}
 	if args.ClusterPath() != "projects/p/locations/l/clusters/c" {
 		t.Errorf("ClusterPath = %s, want projects/p/locations/l/clusters/c", args.ClusterPath())
+	}
+}
+
+func TestListK8SEvents(t *testing.T) {
+	ctx := context.Background()
+
+	// Create fake clientset with some events
+	event1 := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "event1",
+			Namespace: "default",
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Kind: "Pod",
+			Name: "my-pod",
+		},
+		Reason:        "Scheduled",
+		Message:       "Successfully assigned default/my-pod to node1",
+		LastTimestamp: metav1.Time{Time: time.Now().Add(-10 * time.Minute)},
+	}
+	event2 := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "event2",
+			Namespace: "default",
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Kind: "Pod",
+			Name: "my-pod",
+		},
+		Reason:        "Pulled",
+		Message:       "Container image already present on machine",
+		LastTimestamp: metav1.Time{Time: time.Now().Add(-5 * time.Minute)},
+	}
+
+	fakeClientset := fake.NewSimpleClientset(event1, event2)
+
+	mockProvider := &mockClientProvider{
+		kubernetesClient: fakeClientset,
+	}
+
+	h := &handlers{
+		c:        &config.Config{},
+		provider: mockProvider,
+	}
+
+	args := &listK8SEventsArgs{
+		Namespace: "default",
+	}
+	args.ProjectID = "p"
+	args.Location = "l"
+	args.ClusterName = "c"
+
+	result, _, err := h.listK8SEvents(ctx, &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatalf("listK8SEvents failed: %v", err)
+	}
+
+	if result.IsError {
+		t.Fatalf("listK8SEvents returned error result: %v", result.Content[0])
+	}
+
+	if len(result.Content) != 1 {
+		t.Fatalf("len(result.Content) = %d, want 1", len(result.Content))
+	}
+
+	textContent, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("result.Content[0] is not TextContent")
+	}
+
+	// Verify output contains events
+	if !strings.Contains(textContent.Text, "Scheduled") {
+		t.Errorf("output does not contain 'Scheduled'")
+	}
+	if !strings.Contains(textContent.Text, "Pulled") {
+		t.Errorf("output does not contain 'Pulled'")
+	}
+
+	// Verify sorting (newest first)
+	lines := strings.Split(strings.TrimSpace(textContent.Text), "\n")
+	if len(lines) < 3 {
+		t.Fatalf("len(lines) = %d, want at least 3 (header + 2 events)", len(lines))
+	}
+	// Line 0 is header
+	// Line 1 should be event2 (newer)
+	// Line 2 should be event1 (older)
+	if !strings.Contains(lines[1], "Pulled") {
+		t.Errorf("line 1 does not contain 'Pulled'")
+	}
+	if !strings.Contains(lines[2], "Scheduled") {
+		t.Errorf("line 2 does not contain 'Scheduled'")
+	}
+}
+
+func TestListK8SEvents_WithResourceType(t *testing.T) {
+	ctx := context.Background()
+
+	fakeClientset := fake.NewSimpleClientset()
+
+	// Mock discovery
+	fakeDiscovery := fakeClientset.Discovery().(*fakediscovery.FakeDiscovery)
+	fakeDiscovery.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", Namespaced: true, Kind: "Pod"},
+			},
+		},
+	}
+
+	mockProvider := &mockClientProvider{
+		kubernetesClient: fakeClientset,
+		discoveryClient:  fakeDiscovery,
+	}
+
+	h := &handlers{
+		c:        &config.Config{},
+		provider: mockProvider,
+	}
+
+	args := &listK8SEventsArgs{
+		Namespace:    "default",
+		ResourceType: "pod",
+		Name:         "my-pod",
+	}
+	args.ProjectID = "p"
+	args.Location = "l"
+	args.ClusterName = "c"
+
+	result, _, err := h.listK8SEvents(ctx, &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatalf("listK8SEvents failed: %v", err)
+	}
+
+	if result.IsError {
+		t.Fatalf("listK8SEvents returned error result: %v", result.Content[0])
 	}
 }

--- a/pkg/tools/k8s/events_test.go
+++ b/pkg/tools/k8s/events_test.go
@@ -1,0 +1,51 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"testing"
+)
+
+func TestListK8SEventsArgs_Fields(t *testing.T) {
+	args := listK8SEventsArgs{
+		ResourceType:  "pod",
+		Name:          "my-pod",
+		Namespace:     "default",
+		AllNamespaces: true,
+		Limit:         100,
+	}
+	args.ProjectID = "p"
+	args.Location = "l"
+	args.ClusterName = "c"
+
+	if args.ResourceType != "pod" {
+		t.Errorf("ResourceType = %s, want pod", args.ResourceType)
+	}
+	if args.Name != "my-pod" {
+		t.Errorf("Name = %s, want my-pod", args.Name)
+	}
+	if args.Namespace != "default" {
+		t.Errorf("Namespace = %s, want default", args.Namespace)
+	}
+	if !args.AllNamespaces {
+		t.Errorf("AllNamespaces = %v, want true", args.AllNamespaces)
+	}
+	if args.Limit != 100 {
+		t.Errorf("Limit = %d, want 100", args.Limit)
+	}
+	if args.ClusterPath() != "projects/p/locations/l/clusters/c" {
+		t.Errorf("ClusterPath = %s, want projects/p/locations/l/clusters/c", args.ClusterPath())
+	}
+}

--- a/pkg/tools/k8s/get.go
+++ b/pkg/tools/k8s/get.go
@@ -47,7 +47,7 @@ func (h *handlers) getK8SResource(ctx context.Context, _ *mcp.CallToolRequest, a
 		return params.ErrorResult(fmt.Errorf("failed to get discovery client: %w", err)), nil, nil
 	}
 
-	gvr, isNamespaced, err := ResolveGVR(ctx, discoveryClient, args.ResourceType)
+	gvr, _, isNamespaced, err := ResolveGVR(ctx, discoveryClient, args.ResourceType)
 	if err != nil {
 		return params.ErrorResult(err), nil, nil
 	}

--- a/pkg/tools/k8s/get_test.go
+++ b/pkg/tools/k8s/get_test.go
@@ -15,7 +15,18 @@
 package k8s
 
 import (
+	"context"
+	"strings"
 	"testing"
+
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestGetK8SResourceArgs_Fields(t *testing.T) {
@@ -51,5 +62,85 @@ func TestGetK8SResourceArgs_Fields(t *testing.T) {
 	}
 	if args.ClusterPath() != "projects/p/locations/l/clusters/c" {
 		t.Errorf("ClusterPath = %s, want projects/p/locations/l/clusters/c", args.ClusterPath())
+	}
+}
+
+func TestGetK8SResource(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a fake unstructured pod
+	pod := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      "my-pod",
+				"namespace": "default",
+				"labels": map[string]interface{}{
+					"app": "myapp",
+				},
+			},
+			"status": map[string]interface{}{
+				"phase": "Running",
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, pod)
+
+	// We need to mock discovery for ResolveGVR
+	fakeClientset := fake.NewSimpleClientset()
+	fakeDiscovery := fakeClientset.Discovery().(*fakediscovery.FakeDiscovery)
+	fakeDiscovery.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", Namespaced: true, Kind: "Pod"},
+			},
+		},
+	}
+
+	mockProvider := &mockClientProvider{
+		dynamicClient:   fakeDynamicClient,
+		discoveryClient: fakeDiscovery,
+	}
+
+	h := &handlers{
+		c:        &config.Config{},
+		provider: mockProvider,
+	}
+
+	args := &getK8SResourceArgs{
+		ResourceType: "pod",
+		Name:         "my-pod",
+		Namespace:    "default",
+		OutputFormat: "yaml",
+	}
+	args.ProjectID = "p"
+	args.Location = "l"
+	args.ClusterName = "c"
+
+	result, _, err := h.getK8SResource(ctx, &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatalf("getK8SResource failed: %v", err)
+	}
+
+	if result.IsError {
+		t.Fatalf("getK8SResource returned error result: %v", result.Content[0])
+	}
+
+	if len(result.Content) != 1 {
+		t.Fatalf("len(result.Content) = %d, want 1", len(result.Content))
+	}
+
+	textContent, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("result.Content[0] is not TextContent")
+	}
+
+	// Verify output contains pod name
+	if !strings.Contains(textContent.Text, "my-pod") {
+		t.Errorf("output does not contain 'my-pod'")
 	}
 }

--- a/pkg/tools/k8s/tools.go
+++ b/pkg/tools/k8s/tools.go
@@ -42,5 +42,13 @@ func Install(_ context.Context, s *mcp.Server, c *config.Config) error {
 		},
 	}, h.getK8SResource)
 
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "list_k8s_events",
+		Description: "Retrieves events from a Kubernetes cluster. This is similar to running `kubectl events`.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+	}, h.listK8SEvents)
+
 	return nil
 }

--- a/pkg/tools/k8s/tools.go
+++ b/pkg/tools/k8s/tools.go
@@ -24,7 +24,7 @@ import (
 
 type handlers struct {
 	c        *config.Config
-	provider *ClientProvider
+	provider Provider
 }
 
 // Install registers Kubernetes-related tools with the MCP server.


### PR DESCRIPTION
## Why This Change

This PR implements the `list_k8s_events` tool in the OSS repository to match the hosted service. This allows users to inspect Kubernetes events directly through the MCP server.

## What Changed
Added the `list_k8s_events` tool to the `pkg/tools/k8s` package and addressed review feedback.

Files:

• `pkg/tools/k8s/client.go`
• `pkg/tools/k8s/discovery.go`
• `pkg/tools/k8s/events.go`
• `pkg/tools/k8s/events_test.go`
• `pkg/tools/k8s/get.go`
• `pkg/tools/k8s/get_test.go`
• `pkg/tools/k8s/tools.go`

Added/Changed/Fixed:

• Added `list_k8s_events` tool to fetch and format Kubernetes events.
• Fixed namespace handling to ensure `AllNamespaces: true` overrides specific namespace requests.
• Fixed event message formatting by replacing newlines and tabs with spaces to prevent breaking `tabwriter` output.
• Renamed `K8sClientProvider` to `Provider` to fix stuttering linter warning.
• Fixed unused parameter warnings in `events_test.go`.

## Why This Matters

### 1
Parity with hosted service: Ensures the OSS version has the same capabilities for Kubernetes event inspection.

### 2
Improved debugging: Allows users to see events directly, facilitating troubleshooting.

## Context

This work was tracked in conversation `44dbd271-38f7-4470-801c-9c545f001b0b` and continued in `290872cb-aebe-4aba-8066-6a0ea37ce90d`.

## Testing

• Ran unit tests `go test ./pkg/tools/k8s/...` - All passed.
• Ran `make presubmit` - All checks passed.
• Added unit tests for namespace override behavior.

--------
TAG=agy
CONV=290872cb-aebe-4aba-8066-6a0ea37ce90d
