### PR TITLE
chore(ci): make eval-on-pr non-blocking

### DIFF
--- a/.github/workflows/eval-on-pr.yml
+++ b/.github/workflows/eval-on-pr.yml
@@ -53,6 +53,7 @@ jobs:
           ./venv/bin/pip install --index-url https://pypi.org/simple -r pkg/agents/evals/requirements.txt
 
       - name: Run Evaluation
+        continue-on-error: true
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |


### PR DESCRIPTION
# chore(ci): make eval-on-pr non-blocking

## Summary
This PR modifies the `eval-on-pr` workflow to make the "Run Evaluation" step non-blocking. This is achieved by adding `continue-on-error: true` to the step.

## Rationale
The evaluation tests currently fail due to auth problem. Making them non-blocking prevents them from blocking the PR merge process while still providing the evaluation results in the job summary.

