### PR TITLE
chore(ci): skip evaluation job for fork pull requests

### DIFF
--- a/.github/workflows/eval-on-pr.yml
+++ b/.github/workflows/eval-on-pr.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   evaluate:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     permissions:
       contents: read


### PR DESCRIPTION
# chore(ci): skip evaluation job for fork pull requests

## Goal / Description
This pull request updates the `eval-on-pr.yml` workflow to skip running the agent baseline evaluation tests for pull requests that originate from fork repositories.

This serves as a temporary solution to unblock projects.

## Rationale
By default, GitHub Actions secrets are not passed to workflows triggered from forks for security authentication reasons. Since the `eval-on-pr.yml` workflow requires GCP credentials (`GCP_SA_KEY`) and Vertex AI credentials (`GEMINI_API_KEY`) to perform the actual agent evaluations, it consistently fails with auth errors when triggered by fork PRs (e.g., Dependabot or external contributors). 

Adding `if: github.event.pull_request.head.repo.full_name == github.repository` at the job level allows these runs to be skipped cleanly. Skipped jobs appear as gray (Skipped) on GitHub and do not block PR merging via branch protection/tide gates, allowing external contributions to be merged smoothly.
