### PR TITLE
feat(dk): implement real HTTP connection for SearchDocuments

### DIFF
--- a/pkg/agents/manifestgen/manifestgen.go
+++ b/pkg/agents/manifestgen/manifestgen.go
@@ -314,7 +314,7 @@ func Install(ctx context.Context, s *mcp.Server, c *config.Config) error {
 		return fmt.Errorf("failed to create llm client: %w", err)
 	}
 
-	dkClient := dk.NewRealDeveloperKnowledgeClient()
+	dkClient := dk.NewRealDeveloperKnowledgeClient(os.Getenv("DK_BASE_URL"), os.Getenv("DK_API_KEY"))
 	agent, err := NewAgent(llmClient, c, dkClient)
 	if err != nil {
 		return err

--- a/pkg/agents/manifestgen/manifestgen.go
+++ b/pkg/agents/manifestgen/manifestgen.go
@@ -314,7 +314,7 @@ func Install(ctx context.Context, s *mcp.Server, c *config.Config) error {
 		return fmt.Errorf("failed to create llm client: %w", err)
 	}
 
-	dkClient := dk.NewRealDeveloperKnowledgeClient(c.DKBaseURL(), c.DKAPIKey())
+	dkClient := dk.NewRealDeveloperKnowledgeClient(c.DKBaseURL(), c.DKAPIKey(), c.UserAgent())
 	agent, err := NewAgent(llmClient, c, dkClient)
 	if err != nil {
 		return err

--- a/pkg/agents/manifestgen/manifestgen.go
+++ b/pkg/agents/manifestgen/manifestgen.go
@@ -314,7 +314,7 @@ func Install(ctx context.Context, s *mcp.Server, c *config.Config) error {
 		return fmt.Errorf("failed to create llm client: %w", err)
 	}
 
-	dkClient := dk.NewRealDeveloperKnowledgeClient(os.Getenv("DK_BASE_URL"), os.Getenv("DK_API_KEY"))
+	dkClient := dk.NewRealDeveloperKnowledgeClient(c.DKBaseURL(), c.DKAPIKey())
 	agent, err := NewAgent(llmClient, c, dkClient)
 	if err != nil {
 		return err

--- a/pkg/clients/dk/dk_client.go
+++ b/pkg/clients/dk/dk_client.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -52,14 +53,17 @@ func NewRealDeveloperKnowledgeClient(baseURL string, apiKey string) *RealDevelop
 
 // doPost executes a POST request to the Developer Knowledge API.
 func (c *RealDeveloperKnowledgeClient) doPost(ctx context.Context, path string, reqBody interface{}) (string, error) {
-	url := fmt.Sprintf("%s%s", c.baseURL, path)
+	url, err := url.JoinPath(c.baseURL, path)
+	if err != nil {
+		return "", err
+	}
 
 	jsonData, err := json.Marshal(reqBody)
 	if err != nil {
 		return "", err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonData))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return "", err
 	}
@@ -75,7 +79,7 @@ func (c *RealDeveloperKnowledgeClient) doPost(ctx context.Context, path string, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
 		return "", fmt.Errorf("API request failed with status %s: %s", resp.Status, string(body))
 	}
 

--- a/pkg/clients/dk/dk_client.go
+++ b/pkg/clients/dk/dk_client.go
@@ -76,7 +76,7 @@ func (c *RealDeveloperKnowledgeClient) doPost(ctx context.Context, path string, 
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))

--- a/pkg/clients/dk/dk_client.go
+++ b/pkg/clients/dk/dk_client.go
@@ -38,22 +38,24 @@ type RealDeveloperKnowledgeClient struct {
 	baseURL    string
 	httpClient *http.Client
 	apiKey     string
+	userAgent  string
 }
 
 // NewRealDeveloperKnowledgeClient creates a new real client instance.
-func NewRealDeveloperKnowledgeClient(baseURL string, apiKey string) *RealDeveloperKnowledgeClient {
+func NewRealDeveloperKnowledgeClient(baseURL string, apiKey string, userAgent string) *RealDeveloperKnowledgeClient {
 	return &RealDeveloperKnowledgeClient{
 		baseURL: baseURL,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
-		apiKey: apiKey,
+		apiKey:    apiKey,
+		userAgent: userAgent,
 	}
 }
 
 // doPost executes a POST request to the Developer Knowledge API.
 func (c *RealDeveloperKnowledgeClient) doPost(ctx context.Context, path string, reqBody interface{}) (string, error) {
-	url, err := url.JoinPath(c.baseURL, path)
+	reqURL, err := url.JoinPath(c.baseURL, path)
 	if err != nil {
 		return "", err
 	}
@@ -63,13 +65,16 @@ func (c *RealDeveloperKnowledgeClient) doPost(ctx context.Context, path string, 
 		return "", err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return "", err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if c.apiKey != "" {
 		req.Header.Set("X-Goog-Api-Key", c.apiKey)
+	}
+	if c.userAgent != "" {
+		req.Header.Set("User-Agent", c.userAgent)
 	}
 
 	resp, err := c.httpClient.Do(req)

--- a/pkg/clients/dk/dk_client.go
+++ b/pkg/clients/dk/dk_client.go
@@ -16,8 +16,12 @@
 package dk
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 )
 
 // DeveloperKnowledgeClient defines the interface for interacting with the Developer Knowledge API.
@@ -27,14 +31,23 @@ type DeveloperKnowledgeClient interface {
 	SearchDocuments(ctx context.Context, query string) (string, error)
 }
 
-// RealDeveloperKnowledgeClient is the actual implementation (stubbed for now).
+// RealDeveloperKnowledgeClient is the actual implementation.
 type RealDeveloperKnowledgeClient struct {
-	// Add configuration fields here (e.g., API key, base URL)
+	baseURL    string
+	httpClient *http.Client
+	apiKey     string
 }
 
 // NewRealDeveloperKnowledgeClient creates a new real client instance.
-func NewRealDeveloperKnowledgeClient() *RealDeveloperKnowledgeClient {
-	return &RealDeveloperKnowledgeClient{}
+func NewRealDeveloperKnowledgeClient(baseURL string, apiKey string) *RealDeveloperKnowledgeClient {
+	if baseURL == "" {
+		baseURL = "https://knowledge.googleapis.com"
+	}
+	return &RealDeveloperKnowledgeClient{
+		baseURL:    baseURL,
+		httpClient: &http.Client{},
+		apiKey:     apiKey,
+	}
 }
 
 // GetDocuments fetches specific documents by their IDs.
@@ -48,6 +61,40 @@ func (c *RealDeveloperKnowledgeClient) AnswerQuery(_ context.Context, _ string) 
 }
 
 // SearchDocuments searches for documents related to a query.
-func (c *RealDeveloperKnowledgeClient) SearchDocuments(_ context.Context, _ string) (string, error) {
-	return "", fmt.Errorf("SearchDocuments not implemented")
+func (c *RealDeveloperKnowledgeClient) SearchDocuments(ctx context.Context, query string) (string, error) {
+	url := fmt.Sprintf("%s/v1/documents:searchDocumentChunks", c.baseURL)
+
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"query": query,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(reqBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.apiKey != "" {
+		req.Header.Set("X-Goog-Api-Key", c.apiKey)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("API request failed with status %s: %s", resp.Status, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
 }

--- a/pkg/clients/dk/dk_client.go
+++ b/pkg/clients/dk/dk_client.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 )
 
 // DeveloperKnowledgeClient defines the interface for interacting with the Developer Knowledge API.
@@ -40,38 +41,25 @@ type RealDeveloperKnowledgeClient struct {
 
 // NewRealDeveloperKnowledgeClient creates a new real client instance.
 func NewRealDeveloperKnowledgeClient(baseURL string, apiKey string) *RealDeveloperKnowledgeClient {
-	if baseURL == "" {
-		baseURL = "https://knowledge.googleapis.com"
-	}
 	return &RealDeveloperKnowledgeClient{
-		baseURL:    baseURL,
-		httpClient: &http.Client{},
-		apiKey:     apiKey,
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		apiKey: apiKey,
 	}
 }
 
-// GetDocuments fetches specific documents by their IDs.
-func (c *RealDeveloperKnowledgeClient) GetDocuments(_ context.Context, _ []string) (string, error) {
-	return "", fmt.Errorf("GetDocuments not implemented")
-}
+// doPost executes a POST request to the Developer Knowledge API.
+func (c *RealDeveloperKnowledgeClient) doPost(ctx context.Context, path string, reqBody interface{}) (string, error) {
+	url := fmt.Sprintf("%s%s", c.baseURL, path)
 
-// AnswerQuery answers a query based on the knowledge base.
-func (c *RealDeveloperKnowledgeClient) AnswerQuery(_ context.Context, _ string) (string, error) {
-	return "", fmt.Errorf("AnswerQuery not implemented")
-}
-
-// SearchDocuments searches for documents related to a query.
-func (c *RealDeveloperKnowledgeClient) SearchDocuments(ctx context.Context, query string) (string, error) {
-	url := fmt.Sprintf("%s/v1/documents:searchDocumentChunks", c.baseURL)
-
-	reqBody, err := json.Marshal(map[string]interface{}{
-		"query": query,
-	})
+	jsonData, err := json.Marshal(reqBody)
 	if err != nil {
 		return "", err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(reqBody))
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return "", err
 	}
@@ -97,4 +85,21 @@ func (c *RealDeveloperKnowledgeClient) SearchDocuments(ctx context.Context, quer
 	}
 
 	return string(body), nil
+}
+
+// GetDocuments fetches specific documents by their IDs.
+func (c *RealDeveloperKnowledgeClient) GetDocuments(_ context.Context, _ []string) (string, error) {
+	return "", fmt.Errorf("GetDocuments not implemented")
+}
+
+// AnswerQuery answers a query based on the knowledge base.
+func (c *RealDeveloperKnowledgeClient) AnswerQuery(_ context.Context, _ string) (string, error) {
+	return "", fmt.Errorf("AnswerQuery not implemented")
+}
+
+// SearchDocuments searches for documents related to a query.
+func (c *RealDeveloperKnowledgeClient) SearchDocuments(ctx context.Context, query string) (string, error) {
+	return c.doPost(ctx, "/v1/documents:searchDocumentChunks", map[string]interface{}{
+		"query": query,
+	})
 }

--- a/pkg/clients/dk/dk_client_test.go
+++ b/pkg/clients/dk/dk_client_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -55,6 +56,9 @@ func TestRealDeveloperKnowledgeClient_SearchDocuments(t *testing.T) {
 		if r.Header.Get("Content-Type") != "application/json" {
 			t.Errorf("Expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
 		}
+		if r.Header.Get("User-Agent") != "gke-mcp/test" {
+			t.Errorf("Expected User-Agent gke-mcp/test, got %s", r.Header.Get("User-Agent"))
+		}
 
 		var body map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -69,12 +73,30 @@ func TestRealDeveloperKnowledgeClient_SearchDocuments(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewRealDeveloperKnowledgeClient(server.URL, "test-api-key")
+	client := NewRealDeveloperKnowledgeClient(server.URL, "test-api-key", "gke-mcp/test")
 	resp, err := client.SearchDocuments(context.Background(), expectedQuery)
 	if err != nil {
 		t.Fatalf("SearchDocuments failed: %v", err)
 	}
 	if resp != mockResponse {
 		t.Errorf("Expected response %s, got %s", mockResponse, resp)
+	}
+}
+
+func TestRealDeveloperKnowledgeClient_SearchDocuments_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("Internal Server Error"))
+	}))
+	defer server.Close()
+
+	client := NewRealDeveloperKnowledgeClient(server.URL, "test-api-key", "gke-mcp/test")
+	_, err := client.SearchDocuments(context.Background(), "gke network policy")
+	if err == nil {
+		t.Fatalf("Expected error for non-200 status code, got nil")
+	}
+	expectedErrSubstring := "API request failed with status 500 Internal Server Error: Internal Server Error"
+	if !strings.Contains(err.Error(), expectedErrSubstring) {
+		t.Errorf("Expected error containing %q, got %v", expectedErrSubstring, err)
 	}
 }

--- a/pkg/clients/dk/dk_client_test.go
+++ b/pkg/clients/dk/dk_client_test.go
@@ -84,7 +84,7 @@ func TestRealDeveloperKnowledgeClient_SearchDocuments(t *testing.T) {
 }
 
 func TestRealDeveloperKnowledgeClient_SearchDocuments_Error(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte("Internal Server Error"))
 	}))

--- a/pkg/clients/dk/dk_client_test.go
+++ b/pkg/clients/dk/dk_client_test.go
@@ -16,7 +16,11 @@ package dk
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 )
 
 // MockDeveloperKnowledgeClient is a mock implementation for testing.
@@ -32,4 +36,45 @@ func (m *MockDeveloperKnowledgeClient) AnswerQuery(_ context.Context, query stri
 
 func (m *MockDeveloperKnowledgeClient) SearchDocuments(_ context.Context, query string) (string, error) {
 	return fmt.Sprintf("Mock search results for query: %s", query), nil
+}
+
+func TestRealDeveloperKnowledgeClient_SearchDocuments(t *testing.T) {
+	expectedQuery := "gke network policy"
+	mockResponse := `{"results": [{"chunk": "details"}]}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("Expected method POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/documents:searchDocumentChunks" {
+			t.Errorf("Expected path /v1/documents:searchDocumentChunks, got %s", r.URL.Path)
+		}
+		if r.Header.Get("X-Goog-Api-Key") != "test-api-key" {
+			t.Errorf("Expected API Key header, got %s", r.Header.Get("X-Goog-Api-Key"))
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
+		}
+
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("Failed to decode request body: %v", err)
+		}
+		if body["query"] != expectedQuery {
+			t.Errorf("Expected query %q, got %q", expectedQuery, body["query"])
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	client := NewRealDeveloperKnowledgeClient(server.URL, "test-api-key")
+	resp, err := client.SearchDocuments(context.Background(), expectedQuery)
+	if err != nil {
+		t.Fatalf("SearchDocuments failed: %v", err)
+	}
+	if resp != mockResponse {
+		t.Errorf("Expected response %s, got %s", mockResponse, resp)
+	}
 }

--- a/pkg/clients/dk/dk_client_test.go
+++ b/pkg/clients/dk/dk_client_test.go
@@ -65,7 +65,7 @@ func TestRealDeveloperKnowledgeClient_SearchDocuments(t *testing.T) {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(mockResponse))
+		_, _ = w.Write([]byte(mockResponse))
 	}))
 	defer server.Close()
 

--- a/pkg/clients/dk/dk_client_test.go
+++ b/pkg/clients/dk/dk_client_test.go
@@ -43,7 +43,7 @@ func TestRealDeveloperKnowledgeClient_SearchDocuments(t *testing.T) {
 	mockResponse := `{"results": [{"chunk": "details"}]}`
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "POST" {
+		if r.Method != http.MethodPost {
 			t.Errorf("Expected method POST, got %s", r.Method)
 		}
 		if r.URL.Path != "/v1/documents:searchDocumentChunks" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,8 @@ type Config struct {
 	agentModel        string
 	enableDeleteTools bool
 	anthropicAPIKey   string
+	dkBaseURL         string
+	dkAPIKey          string
 }
 
 // UserAgent returns the user agent string for outbound API calls.
@@ -68,6 +70,16 @@ func (c *Config) AnthropicAPIKey() string {
 	return c.anthropicAPIKey
 }
 
+// DKBaseURL returns the configured Developer Knowledge Base URL.
+func (c *Config) DKBaseURL() string {
+	return c.dkBaseURL
+}
+
+// DKAPIKey returns the configured Developer Knowledge API Key.
+func (c *Config) DKAPIKey() string {
+	return c.dkAPIKey
+}
+
 // New constructs a Config populated from gcloud and build version.
 func New(version string, enableDeleteTools bool) *Config {
 	provider := os.Getenv("GKE_MCP_PROVIDER")
@@ -85,6 +97,12 @@ func New(version string, enableDeleteTools bool) *Config {
 
 	anthropicKey := os.Getenv("ANTHROPIC_API_KEY")
 
+	dkBaseURL := os.Getenv("DK_BASE_URL")
+	if dkBaseURL == "" {
+		dkBaseURL = "https://knowledge.googleapis.com"
+	}
+	dkAPIKey := os.Getenv("DK_API_KEY")
+
 	return &Config{
 		userAgent:         "gke-mcp/" + version,
 		defaultProjectID:  getDefaultProjectID(),
@@ -93,6 +111,8 @@ func New(version string, enableDeleteTools bool) *Config {
 		agentModel:        model,
 		enableDeleteTools: enableDeleteTools,
 		anthropicAPIKey:   anthropicKey,
+		dkBaseURL:         dkBaseURL,
+		dkAPIKey:          dkAPIKey,
 	}
 }
 


### PR DESCRIPTION
# Description

This PR implements the real HTTP connection to the Developer Knowledge API for the `SearchDocuments` method in the `RealDeveloperKnowledgeClient`. It also adds comprehensive unit tests using a local `httptest.Server` to guarantee serialization, headers, and API request validity.

## Key Changes
- **Real Connection Setup**: Added `baseURL`, `httpClient`, and `apiKey` to `RealDeveloperKnowledgeClient` in `pkg/clients/dk/dk_client.go`.
- **SearchDocuments Implementation**: Implemented robust HTTP POST logic sending the search query payload to `/v1/documents:searchDocumentChunks`.
- **Integration with Agent**: Updated `Install` function in `pkg/agents/manifestgen/manifestgen.go` to initialize the client using configured environment variables (`DK_BASE_URL`, `DK_API_KEY`).
- **Unit Testing**: Added a fully mocked net/http test case in `pkg/clients/dk/dk_client_test.go` to validate the JSON payloads, headers (`X-Goog-Api-Key` and `Content-Type`), and successful responses.

## Verification
- Verified Go build compiles without warning: `go build -v ./...`
- Verified all unit tests pass perfectly: `go test -v ./pkg/clients/dk/...` and `go test -v ./...`
- Local presubmits pass successfully: `./dev/tasks/presubmit.sh`

ref #318
