### PR TITLE
feat(dk): implement real HTTP connection for AnswerQuery

### DIFF
--- a/pkg/clients/dk/dk_client.go
+++ b/pkg/clients/dk/dk_client.go
@@ -102,8 +102,10 @@ func (c *RealDeveloperKnowledgeClient) GetDocuments(_ context.Context, _ []strin
 }
 
 // AnswerQuery answers a query based on the knowledge base.
-func (c *RealDeveloperKnowledgeClient) AnswerQuery(_ context.Context, _ string) (string, error) {
-	return "", fmt.Errorf("AnswerQuery not implemented")
+func (c *RealDeveloperKnowledgeClient) AnswerQuery(ctx context.Context, query string) (string, error) {
+	return c.doPost(ctx, "/v1alpha/TopLevel:answerQuery", map[string]interface{}{
+		"query": query,
+	})
 }
 
 // SearchDocuments searches for documents related to a query.

--- a/pkg/clients/dk/dk_client_test.go
+++ b/pkg/clients/dk/dk_client_test.go
@@ -28,15 +28,15 @@ import (
 type MockDeveloperKnowledgeClient struct{}
 
 func (m *MockDeveloperKnowledgeClient) GetDocuments(_ context.Context, documentIDs []string) (string, error) {
-	return fmt.Sprintf("Mock documents for IDs: %v", documentIDs), nil
+	return fmt.Sprintf(`{"documents": [{"id": "%v", "content": "Mock content"}]}`, documentIDs), nil
 }
 
 func (m *MockDeveloperKnowledgeClient) AnswerQuery(_ context.Context, query string) (string, error) {
-	return fmt.Sprintf("Mock answer for query: %s", query), nil
+	return fmt.Sprintf(`{"answer": "Mock answer for query: %s"}`, query), nil
 }
 
 func (m *MockDeveloperKnowledgeClient) SearchDocuments(_ context.Context, query string) (string, error) {
-	return fmt.Sprintf("Mock search results for query: %s", query), nil
+	return fmt.Sprintf(`{"results": [{"chunk": "Mock search results for query: %s"}]}`, query), nil
 }
 
 func TestRealDeveloperKnowledgeClient_SearchDocuments(t *testing.T) {
@@ -62,7 +62,9 @@ func TestRealDeveloperKnowledgeClient_SearchDocuments(t *testing.T) {
 
 		var body map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("Failed to decode request body: %v", err)
+			t.Errorf("Failed to decode request body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
 		if body["query"] != expectedQuery {
 			t.Errorf("Expected query %q, got %q", expectedQuery, body["query"])
@@ -124,7 +126,9 @@ func TestRealDeveloperKnowledgeClient_AnswerQuery(t *testing.T) {
 
 		var body map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("Failed to decode request body: %v", err)
+			t.Errorf("Failed to decode request body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
 		if body["query"] != expectedQuery {
 			t.Errorf("Expected query %q, got %q", expectedQuery, body["query"])

--- a/pkg/clients/dk/dk_client_test.go
+++ b/pkg/clients/dk/dk_client_test.go
@@ -100,3 +100,47 @@ func TestRealDeveloperKnowledgeClient_SearchDocuments_Error(t *testing.T) {
 		t.Errorf("Expected error containing %q, got %v", expectedErrSubstring, err)
 	}
 }
+
+func TestRealDeveloperKnowledgeClient_AnswerQuery(t *testing.T) {
+	expectedQuery := "how do I upgrade GKE cluster"
+	mockResponse := `{"answer": "Use gcloud container clusters upgrade"}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Expected method POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1alpha/TopLevel:answerQuery" {
+			t.Errorf("Expected path /v1alpha/TopLevel:answerQuery, got %s", r.URL.Path)
+		}
+		if r.Header.Get("X-Goog-Api-Key") != "test-api-key" {
+			t.Errorf("Expected API Key header, got %s", r.Header.Get("X-Goog-Api-Key"))
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
+		}
+		if r.Header.Get("User-Agent") != "gke-mcp/test" {
+			t.Errorf("Expected User-Agent gke-mcp/test, got %s", r.Header.Get("User-Agent"))
+		}
+
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("Failed to decode request body: %v", err)
+		}
+		if body["query"] != expectedQuery {
+			t.Errorf("Expected query %q, got %q", expectedQuery, body["query"])
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	client := NewRealDeveloperKnowledgeClient(server.URL, "test-api-key", "gke-mcp/test")
+	resp, err := client.AnswerQuery(context.Background(), expectedQuery)
+	if err != nil {
+		t.Fatalf("AnswerQuery failed: %v", err)
+	}
+	if resp != mockResponse {
+		t.Errorf("Expected response %s, got %s", mockResponse, resp)
+	}
+}


### PR DESCRIPTION
# Description

This PR implements the real HTTP connection to the Developer Knowledge API for the `AnswerQuery` method in the `RealDeveloperKnowledgeClient`. It also adds corresponding unit tests using a local `httptest.Server` to validate headers, payloads, and response parsing.

This branch builds on top of `dk-real-search` (PR #344).

## Key Changes
- **AnswerQuery Implementation**: Implemented the HTTP POST logic targeting `/v1alpha/TopLevel:answerQuery`, serializing the request query payload.
- **Unit Testing**: Added a fully mocked net/http test case `TestRealDeveloperKnowledgeClient_AnswerQuery` to validate payload structures and successful responses.

## Verification
- Verified all unit tests pass perfectly: `go test -v ./pkg/clients/dk/...` and `go test -v ./...`
- Local presubmits pass successfully: `./dev/tasks/presubmit.sh`

ref #318
