### PR TITLE
feat(dk): implement real HTTP connection for GetDocuments

### DIFF
--- a/pkg/clients/dk/dk_client.go
+++ b/pkg/clients/dk/dk_client.go
@@ -97,8 +97,10 @@ func (c *RealDeveloperKnowledgeClient) doPost(ctx context.Context, path string, 
 }
 
 // GetDocuments fetches specific documents by their IDs.
-func (c *RealDeveloperKnowledgeClient) GetDocuments(_ context.Context, _ []string) (string, error) {
-	return "", fmt.Errorf("GetDocuments not implemented")
+func (c *RealDeveloperKnowledgeClient) GetDocuments(ctx context.Context, documentIDs []string) (string, error) {
+	return c.doPost(ctx, "/v1/documents:batchGet", map[string]interface{}{
+		"names": documentIDs,
+	})
 }
 
 // AnswerQuery answers a query based on the knowledge base.

--- a/pkg/clients/dk/dk_client.go
+++ b/pkg/clients/dk/dk_client.go
@@ -98,6 +98,9 @@ func (c *RealDeveloperKnowledgeClient) doPost(ctx context.Context, path string, 
 
 // GetDocuments fetches specific documents by their IDs.
 func (c *RealDeveloperKnowledgeClient) GetDocuments(ctx context.Context, documentIDs []string) (string, error) {
+	if len(documentIDs) == 0 {
+		return `{"documents": []}`, nil
+	}
 	return c.doPost(ctx, "/v1/documents:batchGet", map[string]interface{}{
 		"names": documentIDs,
 	})

--- a/pkg/clients/dk/dk_client_test.go
+++ b/pkg/clients/dk/dk_client_test.go
@@ -209,7 +209,7 @@ func TestRealDeveloperKnowledgeClient_GetDocuments(t *testing.T) {
 
 func TestRealDeveloperKnowledgeClient_GetDocuments_Empty(t *testing.T) {
 	// Create a server that should never be reached
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Errorf("Server should not be called for empty documentIDs")
 		w.WriteHeader(http.StatusInternalServerError)
 	}))

--- a/pkg/clients/dk/dk_client_test.go
+++ b/pkg/clients/dk/dk_client_test.go
@@ -206,3 +206,22 @@ func TestRealDeveloperKnowledgeClient_GetDocuments(t *testing.T) {
 		t.Errorf("Expected response %s, got %s", mockResponse, resp)
 	}
 }
+
+func TestRealDeveloperKnowledgeClient_GetDocuments_Empty(t *testing.T) {
+	// Create a server that should never be reached
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("Server should not be called for empty documentIDs")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := NewRealDeveloperKnowledgeClient(server.URL, "test-api-key", "gke-mcp/test")
+	resp, err := client.GetDocuments(context.Background(), []string{})
+	if err != nil {
+		t.Fatalf("GetDocuments failed: %v", err)
+	}
+	expectedResponse := `{"documents": []}`
+	if resp != expectedResponse {
+		t.Errorf("Expected response %s, got %s", expectedResponse, resp)
+	}
+}

--- a/pkg/clients/dk/dk_client_test.go
+++ b/pkg/clients/dk/dk_client_test.go
@@ -154,7 +154,7 @@ func TestRealDeveloperKnowledgeClient_GetDocuments(t *testing.T) {
 	mockResponse := `{"documents": [{"name": "doc-1"}, {"name": "doc-2"}]}`
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "POST" {
+		if r.Method != http.MethodPost {
 			t.Errorf("Expected method POST, got %s", r.Method)
 		}
 		if r.URL.Path != "/v1/documents:batchGet" {
@@ -166,18 +166,27 @@ func TestRealDeveloperKnowledgeClient_GetDocuments(t *testing.T) {
 		if r.Header.Get("Content-Type") != "application/json" {
 			t.Errorf("Expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
 		}
+		if r.Header.Get("User-Agent") != "gke-mcp/test" {
+			t.Errorf("Expected User-Agent gke-mcp/test, got %s", r.Header.Get("User-Agent"))
+		}
 
 		var body map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("Failed to decode request body: %v", err)
+			t.Errorf("Failed to decode request body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
 		rawNames, ok := body["names"]
 		if !ok {
-			t.Fatalf("Expected key 'names' in request body")
+			t.Errorf("Expected key 'names' in request body")
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
 		namesSlice, ok := rawNames.([]interface{})
 		if !ok {
-			t.Fatalf("Expected 'names' to be a slice")
+			t.Errorf("Expected 'names' to be a slice")
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
 		if len(namesSlice) != 2 || namesSlice[0] != expectedIDs[0] || namesSlice[1] != expectedIDs[1] {
 			t.Errorf("Expected names %v, got %v", expectedIDs, namesSlice)
@@ -188,7 +197,7 @@ func TestRealDeveloperKnowledgeClient_GetDocuments(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewRealDeveloperKnowledgeClient(server.URL, "test-api-key")
+	client := NewRealDeveloperKnowledgeClient(server.URL, "test-api-key", "gke-mcp/test")
 	resp, err := client.GetDocuments(context.Background(), expectedIDs)
 	if err != nil {
 		t.Fatalf("GetDocuments failed: %v", err)

--- a/pkg/clients/dk/dk_client_test.go
+++ b/pkg/clients/dk/dk_client_test.go
@@ -148,3 +148,52 @@ func TestRealDeveloperKnowledgeClient_AnswerQuery(t *testing.T) {
 		t.Errorf("Expected response %s, got %s", mockResponse, resp)
 	}
 }
+
+func TestRealDeveloperKnowledgeClient_GetDocuments(t *testing.T) {
+	expectedIDs := []string{"doc-1", "doc-2"}
+	mockResponse := `{"documents": [{"name": "doc-1"}, {"name": "doc-2"}]}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("Expected method POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/documents:batchGet" {
+			t.Errorf("Expected path /v1/documents:batchGet, got %s", r.URL.Path)
+		}
+		if r.Header.Get("X-Goog-Api-Key") != "test-api-key" {
+			t.Errorf("Expected API Key header, got %s", r.Header.Get("X-Goog-Api-Key"))
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
+		}
+
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("Failed to decode request body: %v", err)
+		}
+		rawNames, ok := body["names"]
+		if !ok {
+			t.Fatalf("Expected key 'names' in request body")
+		}
+		namesSlice, ok := rawNames.([]interface{})
+		if !ok {
+			t.Fatalf("Expected 'names' to be a slice")
+		}
+		if len(namesSlice) != 2 || namesSlice[0] != expectedIDs[0] || namesSlice[1] != expectedIDs[1] {
+			t.Errorf("Expected names %v, got %v", expectedIDs, namesSlice)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	client := NewRealDeveloperKnowledgeClient(server.URL, "test-api-key")
+	resp, err := client.GetDocuments(context.Background(), expectedIDs)
+	if err != nil {
+		t.Fatalf("GetDocuments failed: %v", err)
+	}
+	if resp != mockResponse {
+		t.Errorf("Expected response %s, got %s", mockResponse, resp)
+	}
+}


### PR DESCRIPTION
# Description

This PR implements the final real HTTP connection to the Developer Knowledge API for the `GetDocuments` method in the `RealDeveloperKnowledgeClient`. It also adds corresponding unit tests using a local `httptest.Server` to validate request payloads, headers, and response structures.

This branch builds on top of `dk-real-answer` (PR #345). With this PR, the migration of all client methods in the Developer Knowledge integration is complete!

## Key Changes
- **GetDocuments Implementation**: Implemented the HTTP POST logic targeting `/v1/documents:batchGet`, serializing the slice of document names/IDs.
- **Unit Testing**: Added a fully mocked net/http test case `TestRealDeveloperKnowledgeClient_GetDocuments` to validate name slice structure serialization and successful API response decoding.

## Verification
- Verified all unit tests pass perfectly: `go test -v ./pkg/clients/dk/...` and `go test -v ./...`
- Local presubmits pass successfully: `./dev/tasks/presubmit.sh`

ref #318
