### PR TITLE
ci: fix step-level conditions for baseline evaluation

### DIFF
--- a/.github/workflows/eval-on-pr.yml
+++ b/.github/workflows/eval-on-pr.yml
@@ -14,7 +14,6 @@ on:
 jobs:
   evaluate:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
 
     permissions:
       contents: read
@@ -26,6 +25,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Authenticate to Google Cloud
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: google-github-actions/auth@v3
         with:
           credentials_json: "${{ secrets.GCP_SA_KEY }}"
@@ -54,7 +54,7 @@ jobs:
           ./venv/bin/pip install --index-url https://pypi.org/simple -r pkg/agents/evals/requirements.txt
 
       - name: Run Evaluation
-        continue-on-error: true
+        if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |

--- a/.github/workflows/eval-on-pr.yml
+++ b/.github/workflows/eval-on-pr.yml
@@ -10,6 +10,7 @@ on:
     branches: [main]
     paths:
       - "pkg/agents/**"
+      - ".github/workflows/eval-on-pr.yml"
 
 jobs:
   evaluate:

--- a/.github/workflows/eval-on-pr.yml
+++ b/.github/workflows/eval-on-pr.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.22"
+          go-version-file: "go.mod"
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/pkg/agents/manifestgen/manifestgen.go
+++ b/pkg/agents/manifestgen/manifestgen.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // Package manifestgen provides an agent for generating Kubernetes manifests.
+// Dummy change to trigger baseline evaluation workflow test.
 package manifestgen
 
 import (

--- a/pkg/agents/manifestgen/manifestgen.go
+++ b/pkg/agents/manifestgen/manifestgen.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // Package manifestgen provides an agent for generating Kubernetes manifests.
-// Dummy change to trigger baseline evaluation workflow test.
 package manifestgen
 
 import (


### PR DESCRIPTION
# Pull Request

## Why This Change

This fixes GKE-MCP Agent Baseline Evaluation workflow behavior for PRs originating from forks. 

1. We move the repo comparison check (`github.event.pull_request.head.repo.full_name == github.repository`) from the job level into the individual steps requiring GCP authentication and evaluation run (`Authenticate to Google Cloud` and `Run Evaluation` steps).
2. We remove `continue-on-error: true` on the `Run Evaluation` step so that if a real evaluation run (non-fork) fails, the check fails.

Under this approach, on a fork PR, the setup steps (e.g. checkout, install dependencies, build UI and server) run and succeed, but the GCP auth and Pytest evaluation steps are gracefully skipped. Because skipping steps in a job results in a successful job/check run, the status checks on the PR will pass successfully.

To verify this workflow behavior and ensure it gets triggered, we set the eval to run on every eval-on-pr.yml change as well.

## What Changed

1. Modified `.github/workflows/eval-on-pr.yml`:
   - Removed job-level `if` condition.
   - Added step-level `if` conditions to `Authenticate to Google Cloud` and `Run Evaluation` steps.
   - Removed `continue-on-error: true` from the `Run Evaluation` step to allow proper failure status propagation on target repo PRs.
   - Set to run on changes in itself.

**Files:**

- `.github/workflows/eval-on-pr.yml`

**Added/Changed/Fixed:**

- Changed job-level conditional to step-level conditional in `eval-on-pr.yml`.
- Removed `continue-on-error: true` in evaluation run step.

## Context

This experiment is aimed at finding the cleanest, safest, and most correct setup for the automated evaluation runs.

## Testing

```bash
./dev/tasks/presubmit.sh  # Pass
```
