### PR TITLE
ci: Enable Auto-Running Evaluations on Community Forks

### DIFF
--- a/.github/workflows/eval-on-pr.yml
+++ b/.github/workflows/eval-on-pr.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   evaluate:
     runs-on: ubuntu-latest
-
     permissions:
       contents: read
 
@@ -23,10 +22,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Authenticate to Google Cloud
-        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: google-github-actions/auth@v3
         with:
           credentials_json: "${{ secrets.GCP_SA_KEY }}"
@@ -55,7 +54,6 @@ jobs:
           ./venv/bin/pip install --index-url https://pypi.org/simple -r pkg/agents/evals/requirements.txt
 
       - name: Run Evaluation
-        if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |


### PR DESCRIPTION
### 🤖 Enable Auto-Running Evaluations on Community Forks
Building upon the transition to `pull_request_target` (#347), this PR unblocks the execution of our baseline evaluation suite (`test_compare_baseline.py`) for all external fork pull requests.
#### 🛠️ Changes Implemented
* **Fork Checkout**: Explicitly configures `actions/checkout` to pull the head code and SHA of incoming fork pull requests.
* **Removed Skips**: Strips out step-level repository origin checks so that external PRs execute the full compilation, setup, and evaluation pipeline automatically using base repository secrets.
