### PR TITLE
feat(k8s): implement get_k8s_version tool

### DIFF
--- a/pkg/tools/k8s/tools.go
+++ b/pkg/tools/k8s/tools.go
@@ -50,5 +50,13 @@ func Install(_ context.Context, s *mcp.Server, c *config.Config) error {
 		},
 	}, h.listK8SEvents)
 
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "get_k8s_version",
+		Description: "Retrieves Kubernetes client and server versions for a given cluster. This is similar to running `kubectl version`.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+	}, h.getK8SVersion)
+
 	return nil
 }

--- a/pkg/tools/k8s/tools.go
+++ b/pkg/tools/k8s/tools.go
@@ -52,7 +52,7 @@ func Install(_ context.Context, s *mcp.Server, c *config.Config) error {
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "get_k8s_version",
-		Description: "Retrieves Kubernetes client and server versions for a given cluster. This is similar to running `kubectl version`.",
+		Description: "Retrieves the Kubernetes server version for a given cluster. This is similar to running kubectl version.",
 		Annotations: &mcp.ToolAnnotations{
 			ReadOnlyHint: true,
 		},

--- a/pkg/tools/k8s/version.go
+++ b/pkg/tools/k8s/version.go
@@ -27,6 +27,9 @@ type getK8SVersionArgs struct {
 }
 
 func (h *handlers) getK8SVersion(ctx context.Context, _ *mcp.CallToolRequest, args *getK8SVersionArgs) (*mcp.CallToolResult, any, error) {
+	if args == nil {
+		return params.ErrorResult(fmt.Errorf("args cannot be nil")), nil, nil
+	}
 	clusterPath := args.ClusterPath()
 
 	discoveryClient, err := h.provider.DiscoveryClient(ctx, clusterPath)

--- a/pkg/tools/k8s/version.go
+++ b/pkg/tools/k8s/version.go
@@ -1,0 +1,47 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/params"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type getK8SVersionArgs struct {
+	params.Cluster
+}
+
+func (h *handlers) getK8SVersion(ctx context.Context, _ *mcp.CallToolRequest, args *getK8SVersionArgs) (*mcp.CallToolResult, any, error) {
+	clusterPath := args.ClusterPath()
+
+	discoveryClient, err := h.provider.DiscoveryClient(ctx, clusterPath)
+	if err != nil {
+		return params.ErrorResult(fmt.Errorf("failed to get discovery client: %w", err)), nil, nil
+	}
+
+	version, err := discoveryClient.ServerVersion()
+	if err != nil {
+		return params.ErrorResult(fmt.Errorf("failed to get server version: %w", err)), nil, nil
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: fmt.Sprintf("Server Version: %s", version.GitVersion)},
+		},
+	}, nil, nil
+}

--- a/pkg/tools/k8s/version_test.go
+++ b/pkg/tools/k8s/version_test.go
@@ -1,0 +1,82 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
+)
+
+type mockDiscovery struct {
+	discovery.DiscoveryInterface
+	version *version.Info
+	err     error
+}
+
+func (m *mockDiscovery) ServerVersion() (*version.Info, error) {
+	return m.version, m.err
+}
+
+func TestGetK8SVersion(t *testing.T) {
+	ctx := context.Background()
+
+	mockDisc := &mockDiscovery{
+		version: &version.Info{
+			GitVersion: "v1.27.3",
+		},
+	}
+
+	mockProvider := &mockClientProvider{
+		discoveryClient: mockDisc,
+	}
+
+	h := &handlers{
+		c:        &config.Config{},
+		provider: mockProvider,
+	}
+
+	args := &getK8SVersionArgs{}
+	args.ProjectID = "p"
+	args.Location = "l"
+	args.ClusterName = "c"
+
+	result, _, err := h.getK8SVersion(ctx, &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatalf("getK8SVersion failed: %v", err)
+	}
+
+	if result.IsError {
+		t.Fatalf("getK8SVersion returned error result: %v", result.Content[0])
+	}
+
+	if len(result.Content) != 1 {
+		t.Fatalf("len(result.Content) = %d, want 1", len(result.Content))
+	}
+
+	textContent, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("result.Content[0] is not TextContent")
+	}
+
+	if !strings.Contains(textContent.Text, "v1.27.3") {
+		t.Errorf("output %q does not contain %q", textContent.Text, "v1.27.3")
+	}
+}


### PR DESCRIPTION
# Pull Request

## Why This Change

This PR adds the `get_k8s_version` tool to the OSS repository to match the functionality available in the hosted service, as requested by the user.

## What Changed

**Files:**

- `pkg/tools/k8s/version.go`
- `pkg/tools/k8s/tools.go`
- `pkg/tools/k8s/version_test.go`

**Added/Changed/Fixed:**

- Added `getK8SVersion` handler in `version.go`.
- Registered `get_k8s_version` tool in `tools.go`.
- Added unit tests in `version_test.go`.

## Why This Matters

It brings the OSS repository closer to feature parity with the hosted service for Kubernetes tools.

## Context

Requested by user to match hosted service tools.

## Testing

```bash
go test -v ./pkg/tools/k8s/... # Pass
```

Note: `./dev/tasks/presubmit.sh` failed on `./dev/tasks/format.sh` due to a certificate issue when trying to download `addlicense` (`x509: certificate signed by unknown authority`). I ran `gofmt` manually and it was clean. Unit tests passed.
