### PR TITLE
chore: update owners and automatic reviewers

### DIFF
--- a/.github/auto_request_review.yml
+++ b/.github/auto_request_review.yml
@@ -7,8 +7,8 @@ reviewers:
   groups:
     repository-owners:
       - bradhoekstra
-      - dshnayder
       - GinnyJI
+      - haoxuw
       - jayantid
       - stalhaali
       - toshiowang

--- a/OWNERS
+++ b/OWNERS
@@ -5,6 +5,7 @@ approvers:
 - dshnayder
 - erain
 - GinnyJI
+- haoxuw
 - jayantid
 - juli4n
 - krzyzacy


### PR DESCRIPTION
# Pull Request

## Why This Change

Update owners and automatic reviewers to reflect current team composition. Added `haoxuw` and removed `dshnayder` from automatic reviewers.

## What Changed

**Files:**

- `.github/auto_request_review.yml`
- `OWNERS`

**Added/Changed/Fixed:**

- Added `haoxuw` to `OWNERS` and `.github/auto_request_review.yml`.
- Removed `dshnayder` from `.github/auto_request_review.yml`.

## Why This Matters

Ensures correct people are requested for review and have approval rights.

## Context

None.

## Testing

```bash
./dev/tasks/presubmit.sh  # Failed due to network restriction in sandbox
```

Presubmit failed at `./dev/tasks/format.sh` because it tried to access `proxy.golang.org` to get `github.com/google/addlicense@master` and was blocked by the sandbox network restrictions.
