### PR TITLE
feat(k8s): add delete_k8s_resource tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ For detailed instructions on how to connect the GKE MCP Server to various AI cli
 - `get_k8s_changelog`: Get Kubernetes changelog for upgrades.
 - `get_gke_release_notes`: Get GKE release notes.
 - `generate_manifest`: Generate a Kubernetes manifest using Vertex AI.
+- `delete_k8s_resource`: Delete a Kubernetes resource from a cluster.
 
 ## MCP Prompts
 

--- a/pkg/tools/k8s/delete.go
+++ b/pkg/tools/k8s/delete.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/params"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+)
+
+type deleteK8SResourceArgs struct {
+	params.Cluster
+	ResourceType string `json:"resourceType" jsonschema:"Required. The type of resource to delete. Kubernetes resource/kind name in singular form, lower case. e.g. \"pod\", \"deployment\", \"service\"."`
+	Name         string `json:"name" jsonschema:"Required. The name of the resource to delete."`
+	Namespace    string `json:"namespace,omitempty" jsonschema:"Optional. The namespace of the resource. If not specified, \"default\" is used."`
+	Cascade      string `json:"cascade,omitempty" jsonschema:"Optional. The cascading deletion policy to use. If not specified, 'background' is used. Valid values are 'background', 'foreground', and 'orphan'."`
+	DryRun       bool   `json:"dryRun,omitempty" jsonschema:"Optional. If true, run in dry-run mode."`
+}
+
+func (h *handlers) deleteK8SResource(ctx context.Context, _ *mcp.CallToolRequest, args *deleteK8SResourceArgs) (*mcp.CallToolResult, any, error) {
+	clusterPath := args.ClusterPath()
+
+	discoveryClient, err := h.provider.DiscoveryClient(ctx, clusterPath)
+	if err != nil {
+		return params.ErrorResult(fmt.Errorf("failed to get discovery client: %w", err)), nil, nil
+	}
+
+	gvr, _, isNamespaced, err := ResolveGVR(ctx, discoveryClient, args.ResourceType)
+	if err != nil {
+		return params.ErrorResult(err), nil, nil
+	}
+
+	dynamicClient, err := h.provider.DynamicClient(ctx, clusterPath)
+	if err != nil {
+		return params.ErrorResult(fmt.Errorf("failed to get dynamic client: %w", err)), nil, nil
+	}
+
+	var resourceInterface dynamic.ResourceInterface
+	if isNamespaced {
+		ns := args.Namespace
+		if ns == "" {
+			ns = "default"
+		}
+		resourceInterface = dynamicClient.Resource(gvr).Namespace(ns)
+	} else {
+		resourceInterface = dynamicClient.Resource(gvr)
+	}
+
+	deleteOptions := metav1.DeleteOptions{}
+	if args.Cascade != "" {
+		var propagationPolicy metav1.DeletionPropagation
+		switch args.Cascade {
+		case "background":
+			propagationPolicy = metav1.DeletePropagationBackground
+		case "foreground":
+			propagationPolicy = metav1.DeletePropagationForeground
+		case "orphan":
+			propagationPolicy = metav1.DeletePropagationOrphan
+		default:
+			return params.ErrorResult(fmt.Errorf("invalid cascade policy: %s", args.Cascade)), nil, nil
+		}
+		deleteOptions.PropagationPolicy = &propagationPolicy
+	}
+
+	if args.DryRun {
+		deleteOptions.DryRun = []string{"All"}
+	}
+
+	err = resourceInterface.Delete(ctx, args.Name, deleteOptions)
+	if err != nil {
+		return params.ErrorResult(fmt.Errorf("failed to delete resource: %w", err)), nil, nil
+	}
+
+	result := fmt.Sprintf("Resource %s/%s (kind: %s) deleted", args.Namespace, args.Name, args.ResourceType)
+	if args.DryRun {
+		result += " (dry-run)"
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: result},
+		},
+	}, nil, nil
+}

--- a/pkg/tools/k8s/delete.go
+++ b/pkg/tools/k8s/delete.go
@@ -52,14 +52,17 @@ func (h *handlers) deleteK8SResource(ctx context.Context, _ *mcp.CallToolRequest
 	}
 
 	var resourceInterface dynamic.ResourceInterface
+	var resourceDesc string
 	if isNamespaced {
 		ns := args.Namespace
 		if ns == "" {
 			ns = "default"
 		}
 		resourceInterface = dynamicClient.Resource(gvr).Namespace(ns)
+		resourceDesc = fmt.Sprintf("%s/%s", ns, args.Name)
 	} else {
 		resourceInterface = dynamicClient.Resource(gvr)
+		resourceDesc = args.Name
 	}
 
 	deleteOptions := metav1.DeleteOptions{}
@@ -87,7 +90,7 @@ func (h *handlers) deleteK8SResource(ctx context.Context, _ *mcp.CallToolRequest
 		return params.ErrorResult(fmt.Errorf("failed to delete resource: %w", err)), nil, nil
 	}
 
-	result := fmt.Sprintf("Resource %s/%s (kind: %s) deleted", args.Namespace, args.Name, args.ResourceType)
+	result := fmt.Sprintf("Resource %s (kind: %s) deleted", resourceDesc, args.ResourceType)
 	if args.DryRun {
 		result += " (dry-run)"
 	}

--- a/pkg/tools/k8s/delete_test.go
+++ b/pkg/tools/k8s/delete_test.go
@@ -1,0 +1,223 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestDeleteK8SResource(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a fake unstructured pod
+	pod := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      "my-pod",
+				"namespace": "default",
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, pod)
+
+	// We need to mock discovery for ResolveGVR
+	fakeClientset := fake.NewSimpleClientset()
+	fakeDiscovery := fakeClientset.Discovery().(*fakediscovery.FakeDiscovery)
+	fakeDiscovery.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", Namespaced: true, Kind: "Pod"},
+			},
+		},
+	}
+
+	mockProvider := &mockClientProvider{
+		dynamicClient:   fakeDynamicClient,
+		discoveryClient: fakeDiscovery,
+	}
+
+	h := &handlers{
+		c:        &config.Config{},
+		provider: mockProvider,
+	}
+
+	args := &deleteK8SResourceArgs{
+		ResourceType: "pod",
+		Name:         "my-pod",
+		Namespace:    "default",
+	}
+	args.ProjectID = "p"
+	args.Location = "l"
+	args.ClusterName = "c"
+
+	result, _, err := h.deleteK8SResource(ctx, &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatalf("deleteK8SResource failed: %v", err)
+	}
+
+	if result.IsError {
+		t.Fatalf("deleteK8SResource returned error result: %v", result.Content[0])
+	}
+
+	if len(result.Content) != 1 {
+		t.Fatalf("len(result.Content) = %d, want 1", len(result.Content))
+	}
+
+	textContent, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("result.Content[0] is not TextContent")
+	}
+
+	if !strings.Contains(textContent.Text, "deleted") {
+		t.Errorf("output does not contain 'deleted'")
+	}
+}
+
+func TestDeleteK8SResource_DryRun(t *testing.T) {
+	ctx := context.Background()
+
+	pod := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      "my-pod",
+				"namespace": "default",
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, pod)
+
+	fakeClientset := fake.NewSimpleClientset()
+	fakeDiscovery := fakeClientset.Discovery().(*fakediscovery.FakeDiscovery)
+	fakeDiscovery.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", Namespaced: true, Kind: "Pod"},
+			},
+		},
+	}
+
+	mockProvider := &mockClientProvider{
+		dynamicClient:   fakeDynamicClient,
+		discoveryClient: fakeDiscovery,
+	}
+
+	h := &handlers{
+		c:        &config.Config{},
+		provider: mockProvider,
+	}
+
+	args := &deleteK8SResourceArgs{
+		ResourceType: "pod",
+		Name:         "my-pod",
+		Namespace:    "default",
+		DryRun:       true,
+	}
+	args.ProjectID = "p"
+	args.Location = "l"
+	args.ClusterName = "c"
+
+	result, _, err := h.deleteK8SResource(ctx, &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatalf("deleteK8SResource failed: %v", err)
+	}
+
+	if result.IsError {
+		t.Fatalf("deleteK8SResource returned error result: %v", result.Content[0])
+	}
+
+	textContent, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("result.Content[0] is not TextContent")
+	}
+
+	if !strings.Contains(textContent.Text, "(dry-run)") {
+		t.Errorf("output does not contain '(dry-run)'")
+	}
+}
+
+func TestDeleteK8SResource_InvalidCascade(t *testing.T) {
+	ctx := context.Background()
+
+	fakeClientset := fake.NewSimpleClientset()
+	fakeDiscovery := fakeClientset.Discovery().(*fakediscovery.FakeDiscovery)
+	fakeDiscovery.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", Namespaced: true, Kind: "Pod"},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme)
+
+	h := &handlers{
+		c:        &config.Config{},
+		provider: &mockClientProvider{
+			discoveryClient: fakeDiscovery,
+			dynamicClient:   fakeDynamicClient,
+		},
+	}
+
+	args := &deleteK8SResourceArgs{
+		ResourceType: "pod",
+		Name:         "my-pod",
+		Namespace:    "default",
+		Cascade:      "invalid",
+	}
+	args.ProjectID = "p"
+	args.Location = "l"
+	args.ClusterName = "c"
+
+	result, _, err := h.deleteK8SResource(ctx, &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatalf("deleteK8SResource failed: %v", err)
+	}
+
+	if !result.IsError {
+		t.Fatalf("deleteK8SResource expected error result")
+	}
+
+	textContent, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("result.Content[0] is not TextContent")
+	}
+
+	if !strings.Contains(textContent.Text, "invalid cascade policy") {
+		t.Errorf("output does not contain 'invalid cascade policy'")
+	}
+}

--- a/pkg/tools/k8s/delete_test.go
+++ b/pkg/tools/k8s/delete_test.go
@@ -221,3 +221,68 @@ func TestDeleteK8SResource_InvalidCascade(t *testing.T) {
 		t.Errorf("output does not contain 'invalid cascade policy'")
 	}
 }
+
+func TestDeleteK8SResource_ClusterScoped(t *testing.T) {
+	ctx := context.Background()
+
+	node := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Node",
+			"metadata": map[string]interface{}{
+				"name": "my-node",
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, node)
+
+	fakeClientset := fake.NewSimpleClientset()
+	fakeDiscovery := fakeClientset.Discovery().(*fakediscovery.FakeDiscovery)
+	fakeDiscovery.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "nodes", Namespaced: false, Kind: "Node"},
+			},
+		},
+	}
+
+	mockProvider := &mockClientProvider{
+		dynamicClient:   fakeDynamicClient,
+		discoveryClient: fakeDiscovery,
+	}
+
+	h := &handlers{
+		c:        &config.Config{},
+		provider: mockProvider,
+	}
+
+	args := &deleteK8SResourceArgs{
+		ResourceType: "node",
+		Name:         "my-node",
+	}
+	args.ProjectID = "p"
+	args.Location = "l"
+	args.ClusterName = "c"
+
+	result, _, err := h.deleteK8SResource(ctx, &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatalf("deleteK8SResource failed: %v", err)
+	}
+
+	if result.IsError {
+		t.Fatalf("deleteK8SResource returned error result: %v", result.Content[0])
+	}
+
+	textContent, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("result.Content[0] is not TextContent")
+	}
+
+	expectedMsg := "Resource my-node (kind: node) deleted"
+	if textContent.Text != expectedMsg {
+		t.Errorf("output = %q, want %q", textContent.Text, expectedMsg)
+	}
+}

--- a/pkg/tools/k8s/delete_test.go
+++ b/pkg/tools/k8s/delete_test.go
@@ -186,7 +186,7 @@ func TestDeleteK8SResource_InvalidCascade(t *testing.T) {
 	fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme)
 
 	h := &handlers{
-		c:        &config.Config{},
+		c: &config.Config{},
 		provider: &mockClientProvider{
 			discoveryClient: fakeDiscovery,
 			dynamicClient:   fakeDynamicClient,

--- a/pkg/tools/k8s/tools.go
+++ b/pkg/tools/k8s/tools.go
@@ -63,5 +63,10 @@ func Install(_ context.Context, s *mcp.Server, c *config.Config) error {
 		Description: "Applies a Kubernetes manifest to a cluster using server-side apply. This is similar to running `kubectl apply --server-side`.",
 	}, h.applyK8SManifest)
 
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "delete_k8s_resource",
+		Description: "Deletes a Kubernetes resource from a cluster. This is similar to running `kubectl delete`.",
+	}, h.deleteK8SResource)
+
 	return nil
 }


### PR DESCRIPTION
# Pull Request

## Why This Change

This PR adds the `delete_k8s_resource` tool to the GKE MCP server. This tool allows users (and AI agents) to delete specific Kubernetes resources from a GKE cluster, supporting various options like cascading deletion and dry-run.

## What Changed

Added a new tool `delete_k8s_resource` in `pkg/tools/k8s`.

**Files:**

- `README.md`: Added tool to the list.
- `pkg/tools/k8s/delete.go`: Implementation of the tool.
- `pkg/tools/k8s/delete_test.go`: Tests for the tool.
- `pkg/tools/k8s/tools.go`: Registration of the tool.

**Added/Changed/Fixed:**

- Added `deleteK8SResource` handler.
- Added `deleteK8SResourceArgs` struct for arguments.
- Registered the tool in `tools.go`.
- Added tests for successful deletion, dry-run, and invalid cascade policy.

## Why This Matters

### 1

- Enables full lifecycle management of K8s resources via MCP (Create, Read, Update, Delete). We already had create/update (apply) and read (get), now we have delete.

## Context

Follow-up to the implementation of `apply_k8s_manifest`.

## Testing

```bash
./dev/tasks/presubmit.sh  # Pass
```
