### PR TITLE
Remove Baseline Evaluation Label Requirement

### DIFF
--- a/.github/workflows/eval-on-pr.yml
+++ b/.github/workflows/eval-on-pr.yml
@@ -7,7 +7,7 @@ permissions: read-all
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     branches: [main, "feature/**"]
     paths:
       - "pkg/agents/**"
@@ -27,7 +27,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Authenticate to Google Cloud
-        if: contains(github.event.pull_request.labels.*.name, 'run-evals')
         uses: google-github-actions/auth@v3
         with:
           credentials_json: "${{ secrets.GCP_SA_KEY }}"
@@ -56,7 +55,6 @@ jobs:
           ./venv/bin/pip install --index-url https://pypi.org/simple -r pkg/agents/evals/requirements.txt
 
       - name: Run Evaluation
-        if: contains(github.event.pull_request.labels.*.name, 'run-evals')
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |


### PR DESCRIPTION
### 🤖 Remove GHA Label Gating from Baseline Evaluations

Now that evaluations are triggering correctly under `pull_request_target`, this PR removes the `run-evals` label gating requirement.

#### 🛠️ Changes
* Removed the `if: contains(github.event.pull_request.labels.*.name, 'run-evals')` conditions from both the Google Cloud Authenticate and Run Evaluation steps in `.github/workflows/eval-on-pr.yml`.
* Removed the `labeled` type from the workflow triggers.

This allows baseline evaluations to run automatically on all incoming PRs.
