### PR TITLE
feat(k8s): add get_k8s_logs tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ For detailed instructions on how to connect the GKE MCP Server to various AI cli
 - `get_k8s_changelog`: Get Kubernetes changelog for upgrades.
 - `get_gke_release_notes`: Get GKE release notes.
 - `generate_manifest`: Generate a Kubernetes manifest using Vertex AI.
+- `get_k8s_resource`: Gets one or more Kubernetes resources from a cluster.
+- `list_k8s_events`: Retrieves events from a Kubernetes cluster.
+- `get_k8s_version`: Retrieves the Kubernetes server version for a given cluster.
+- `apply_k8s_manifest`: Applies a Kubernetes manifest to a cluster using server-side apply.
+- `get_k8s_logs`: Gets logs from a Kubernetes container in a pod.
 
 ## MCP Prompts
 

--- a/pkg/tools/k8s/logs.go
+++ b/pkg/tools/k8s/logs.go
@@ -1,0 +1,143 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/params"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type getK8SLogsArgs struct {
+	params.Cluster
+	Name          string `json:"name" jsonschema:"Required. The name of the pod to retrieve logs from. Only 'pod' resource type is supported in this version."`
+	Namespace     string `json:"namespace,omitempty" jsonschema:"Optional. The namespace of the resource. If not specified, \"default\" is used."`
+	AllContainers bool   `json:"allContainers,omitempty" jsonschema:"Optional. If true, retrieve logs from all containers in the pod."`
+	Container     string `json:"container,omitempty" jsonschema:"Optional. The name of the container to retrieve logs from. If not specified, logs from the first container are returned."`
+	Previous      bool   `json:"previous,omitempty" jsonschema:"Optional. If true, retrieve logs from the previous instantiation of the container."`
+	Timestamps    bool   `json:"timestamps,omitempty" jsonschema:"Optional. If true, include timestamps in the log output."`
+	Since         string `json:"since,omitempty" jsonschema:"Optional. Retrieve logs since this duration ago (e.g. \"1h\", \"10m\")."`
+	Tail          int64  `json:"tail,omitempty" jsonschema:"Optional. The number of lines from the end of the logs to show."`
+}
+
+func (h *handlers) getK8SLogs(ctx context.Context, _ *mcp.CallToolRequest, args *getK8SLogsArgs) (*mcp.CallToolResult, any, error) {
+	clusterPath := args.ClusterPath()
+
+	client, err := h.provider.KubernetesClient(ctx, clusterPath)
+	if err != nil {
+		return params.ErrorResult(fmt.Errorf("failed to get kubernetes client: %w", err)), nil, nil
+	}
+
+	rt := "pod"
+	name := args.Name
+	if strings.Contains(name, "/") {
+		parts := strings.Split(name, "/")
+		if len(parts) != 2 {
+			return params.ErrorResult(fmt.Errorf("invalid resource name: %q, expected format is type/name with a single slash", name)), nil, nil
+		}
+		rt, name = parts[0], parts[1]
+	}
+
+	if rt != "pod" {
+		return params.ErrorResult(fmt.Errorf("only 'pod' resource type is supported for logs in this version, got %q", rt)), nil, nil
+	}
+
+	ns := args.Namespace
+	if ns == "" {
+		ns = "default"
+	}
+
+	opts := &corev1.PodLogOptions{
+		Container:  args.Container,
+		Previous:   args.Previous,
+		Timestamps: args.Timestamps,
+	}
+
+	if args.Tail > 0 {
+		opts.TailLines = &args.Tail
+	}
+
+	if args.Since != "" {
+		d, err := time.ParseDuration(args.Since)
+		if err != nil {
+			return params.ErrorResult(fmt.Errorf("failed to parse since duration %q: %w", args.Since, err)), nil, nil
+		}
+		seconds := int64(d.Seconds())
+		opts.SinceSeconds = &seconds
+	}
+
+	var containers []string
+	if args.AllContainers || args.Container == "" {
+		pod, err := client.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return params.ErrorResult(fmt.Errorf("failed to get pod: %w", err)), nil, nil
+		}
+
+		if args.AllContainers {
+			for _, c := range pod.Spec.Containers {
+				containers = append(containers, c.Name)
+			}
+			for _, c := range pod.Spec.InitContainers {
+				containers = append(containers, c.Name)
+			}
+		} else if args.Container == "" {
+			if len(pod.Spec.Containers) > 0 {
+				containers = []string{pod.Spec.Containers[0].Name}
+			}
+		}
+	} else {
+		containers = []string{args.Container}
+	}
+
+	var allLogs []string
+	for _, cName := range containers {
+		cOpts := opts.DeepCopy()
+		cOpts.Container = cName
+
+		req := client.CoreV1().Pods(ns).GetLogs(name, cOpts)
+		podLogs, err := req.Stream(ctx)
+		if err != nil {
+			return params.ErrorResult(fmt.Errorf("failed to get logs for container %q: %w", cName, err)), nil, nil
+		}
+
+		buf := new(strings.Builder)
+		_, err = io.Copy(buf, podLogs)
+		if err != nil {
+			_ = podLogs.Close()
+			return params.ErrorResult(fmt.Errorf("failed to read logs for container %q: %w", cName, err)), nil, nil
+		}
+		if err := podLogs.Close(); err != nil {
+			return params.ErrorResult(fmt.Errorf("failed to close log stream for container %q: %w", cName, err)), nil, nil
+		}
+
+		if len(containers) > 1 {
+			allLogs = append(allLogs, fmt.Sprintf("===== Container: %s =====", cName))
+		}
+		allLogs = append(allLogs, buf.String())
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: strings.Join(allLogs, "\n")},
+		},
+	}, nil, nil
+}

--- a/pkg/tools/k8s/logs.go
+++ b/pkg/tools/k8s/logs.go
@@ -51,8 +51,8 @@ func (h *handlers) getK8SLogs(ctx context.Context, _ *mcp.CallToolRequest, args 
 	name := args.Name
 	if strings.Contains(name, "/") {
 		parts := strings.Split(name, "/")
-		if len(parts) != 2 {
-			return params.ErrorResult(fmt.Errorf("invalid resource name: %q, expected format is type/name with a single slash", name)), nil, nil
+		if len(parts) != 2 || parts[1] == "" {
+			return params.ErrorResult(fmt.Errorf("invalid resource name: %q, expected format is type/name", name)), nil, nil
 		}
 		rt, name = parts[0], parts[1]
 	}
@@ -113,26 +113,35 @@ func (h *handlers) getK8SLogs(ctx context.Context, _ *mcp.CallToolRequest, args 
 		cOpts := opts.DeepCopy()
 		cOpts.Container = cName
 
-		req := client.CoreV1().Pods(ns).GetLogs(name, cOpts)
-		podLogs, err := req.Stream(ctx)
-		if err != nil {
-			return params.ErrorResult(fmt.Errorf("failed to get logs for container %q: %w", cName, err)), nil, nil
-		}
-
-		buf := new(strings.Builder)
-		_, err = io.Copy(buf, podLogs)
-		if err != nil {
-			_ = podLogs.Close()
-			return params.ErrorResult(fmt.Errorf("failed to read logs for container %q: %w", cName, err)), nil, nil
-		}
-		if err := podLogs.Close(); err != nil {
-			return params.ErrorResult(fmt.Errorf("failed to close log stream for container %q: %w", cName, err)), nil, nil
-		}
-
 		if len(containers) > 1 {
 			allLogs = append(allLogs, fmt.Sprintf("===== Container: %s =====", cName))
 		}
-		allLogs = append(allLogs, buf.String())
+
+		req := client.CoreV1().Pods(ns).GetLogs(name, cOpts)
+		podLogs, err := req.Stream(ctx)
+		if err != nil {
+			allLogs = append(allLogs, fmt.Sprintf("Error: failed to stream logs: %v", err))
+			continue
+		}
+
+		const maxLogSize = 1024 * 1024 // 1MB safety limit
+		buf := new(strings.Builder)
+		n, err := io.Copy(buf, io.LimitReader(podLogs, maxLogSize))
+		_ = podLogs.Close()
+
+		if err != nil {
+			allLogs = append(allLogs, fmt.Sprintf("Error: failed to read logs: %v", err))
+			continue
+		}
+
+		logText := buf.String()
+		if n >= maxLogSize {
+			logText += "\n... (logs truncated due to size limit)"
+		}
+		if logText == "" {
+			logText = "(no logs found)"
+		}
+		allLogs = append(allLogs, logText)
 	}
 
 	return &mcp.CallToolResult{

--- a/pkg/tools/k8s/logs_test.go
+++ b/pkg/tools/k8s/logs_test.go
@@ -1,0 +1,106 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetK8SLogsArgs_Fields(t *testing.T) {
+	args := getK8SLogsArgs{
+		Name:          "my-pod",
+		Namespace:     "default",
+		AllContainers: true,
+		Container:     "my-container",
+		Previous:      true,
+		Timestamps:    true,
+		Since:         "1h",
+		Tail:          10,
+	}
+	args.ProjectID = "p"
+	args.Location = "l"
+	args.ClusterName = "c"
+
+	if args.Name != "my-pod" {
+		t.Errorf("Name = %s, want my-pod", args.Name)
+	}
+	if args.Namespace != "default" {
+		t.Errorf("Namespace = %s, want default", args.Namespace)
+	}
+	if !args.AllContainers {
+		t.Errorf("AllContainers = %v, want true", args.AllContainers)
+	}
+	if args.Container != "my-container" {
+		t.Errorf("Container = %s, want my-container", args.Container)
+	}
+	if !args.Previous {
+		t.Errorf("Previous = %v, want true", args.Previous)
+	}
+	if !args.Timestamps {
+		t.Errorf("Timestamps = %v, want true", args.Timestamps)
+	}
+	if args.Since != "1h" {
+		t.Errorf("Since = %s, want 1h", args.Since)
+	}
+	if args.Tail != 10 {
+		t.Errorf("Tail = %d, want 10", args.Tail)
+	}
+}
+
+func TestGetK8SLogs_PodNotFound(t *testing.T) {
+	ctx := context.Background()
+
+	fakeClientset := fake.NewSimpleClientset()
+	mockProvider := &mockClientProvider{
+		kubernetesClient: fakeClientset,
+	}
+
+	h := &handlers{
+		c:        &config.Config{},
+		provider: mockProvider,
+	}
+
+	args := &getK8SLogsArgs{
+		Name:      "non-existent-pod",
+		Namespace: "default",
+	}
+	args.ProjectID = "p"
+	args.Location = "l"
+	args.ClusterName = "c"
+
+	result, _, err := h.getK8SLogs(ctx, &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatalf("getK8SLogs failed: %v", err)
+	}
+
+	if !result.IsError {
+		t.Fatalf("getK8SLogs expected error result, got success")
+	}
+
+	textContent, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("result.Content[0] is not TextContent")
+	}
+
+	if !strings.Contains(textContent.Text, "failed to get pod") {
+		t.Errorf("expected error message to contain 'failed to get pod', got %q", textContent.Text)
+	}
+}

--- a/pkg/tools/k8s/tools.go
+++ b/pkg/tools/k8s/tools.go
@@ -63,5 +63,13 @@ func Install(_ context.Context, s *mcp.Server, c *config.Config) error {
 		Description: "Applies a Kubernetes manifest to a cluster using server-side apply. This is similar to running `kubectl apply --server-side`.",
 	}, h.applyK8SManifest)
 
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "get_k8s_logs",
+		Description: "Gets logs from a Kubernetes container in a pod. This is similar to running `kubectl logs`.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+	}, h.getK8SLogs)
+
 	return nil
 }


### PR DESCRIPTION
# Pull Request

## Why This Change

Implement `get_k8s_logs` tool to match hosted service functionality and schema.

## What Changed

**Files:**

- `pkg/tools/k8s/logs.go`
- `pkg/tools/k8s/logs_test.go`
- `pkg/tools/k8s/tools.go`
- `README.md`

**Added/Changed/Fixed:**

- Added `get_k8s_logs` tool implementation supporting pod logs retrieval.
- Added unit tests for `get_k8s_logs`.
- Registered `get_k8s_logs` in `tools.go`.
- Updated `README.md` to list `get_k8s_logs` and other missing K8s tools.

## Why This Matters

Provides parity with the hosted service and enables users to fetch container logs from pods.

## Context

User requested to match all MCP tools in the hosted service.

## Testing

```bash
./dev/tasks/presubmit.sh  # Pass
go test -v ./pkg/tools/k8s/... # Pass
```

Ran presubmit locally and it passed after fixing a lint error in `logs.go`.
