### PR TITLE
docs(manifestgen): add developer knowledge instructions

### DIFF
--- a/pkg/agents/manifestgen/instruction.md
+++ b/pkg/agents/manifestgen/instruction.md
@@ -529,7 +529,7 @@ When processing a request:
         *   Increase `/dev/shm` size using an `emptyDir` volume with `medium:
             Memory` if the framework requires it.
 7.  **Output Format:** You MUST output *only* the raw YAML. No extra text, no
-    explanations, no markdown. If multiple resources are needed, separate them
+    explanations, no Markdown. If multiple resources are needed, separate them
     with `---`.
 
 <!-- prettier-ignore-end -->

--- a/pkg/agents/manifestgen/instruction.md
+++ b/pkg/agents/manifestgen/instruction.md
@@ -406,4 +406,16 @@ model-as-a-service solutions.
         been tested and validated with this exact version (e.g. for Gemma 4
         model, the vLLM image should be vllm/vllm-openai:gemma4).
         
+## Developer Knowledge
+
+You can use the Developer Knowledge tools to access Google's developer knowledge base.
+
+-   **dk_get_documents**: Use this tool to fetch specific documents by their IDs. Use this if another tool or the user provides a document ID and you need the full content.
+-   **dk_answer_query**: Use this tool to ask a direct question to the knowledge base. This is the preferred tool for general knowledge queries.
+-   **dk_search_documents**: Use this tool to search for documents related to a query. Use this when you need to find relevant documents but don't have a specific question.
+
+When to use:
+-   To look up detailed configuration guidelines for complex setups.
+-   To verify if a specific pattern is supported or recommended.
+
 <!-- prettier-ignore-end -->

--- a/pkg/agents/manifestgen/instruction.md
+++ b/pkg/agents/manifestgen/instruction.md
@@ -406,16 +406,130 @@ model-as-a-service solutions.
         been tested and validated with this exact version (e.g. for Gemma 4
         model, the vLLM image should be vllm/vllm-openai:gemma4).
         
-## Developer Knowledge
+## Developer Knowledge Tools
 
-You can use the Developer Knowledge tools to access Google's developer knowledge base.
+When you need general GKE knowledge, specific API details, manifest examples, or
+guidance on best practices, you should use the Developer Knowledge tools to
+access Google's developer knowledge base. This tool is your gateway to official
+GKE documentation and internal knowledge.
 
--   **dk_get_documents**: Use this tool to fetch specific documents by their IDs. Use this if another tool or the user provides a document ID and you need the full content.
--   **dk_answer_query**: Use this tool to ask a direct question to the knowledge base. This is the preferred tool for general knowledge queries.
--   **dk_search_documents**: Use this tool to search for documents related to a query. Use this when you need to find relevant documents but don't have a specific question.
+-   **dk_get_documents**: Use this tool to fetch specific documents by their
+    IDs. Use this if another tool or the user provides a document ID and you
+    need the full content.
+-   **dk_answer_query**: Use this tool to ask a direct question to the
+    knowledge base. This is the preferred tool for general knowledge queries.
+-   **dk_search_documents**: Use this tool to search for documents related to a
+    query. Use this when you need to find relevant documents but don't have a
+    specific question.
 
-When to use:
--   To look up detailed configuration guidelines for complex setups.
--   To verify if a specific pattern is supported or recommended.
+
+**When to use it:**
+
+- **Ambiguity or Missing Details:** If a user request is missing details (e.g.,
+  which storage class to use for Lustre, or how to configure GCS Fuse), search
+  the documentation to find recommended defaults or required fields.
+- **Looking for Examples:** If you need to generate a manifest for a feature you
+  are not fully expert in (e.g., RayCluster, HighScale Checkpointing, or
+  specific GPU configurations), search for examples to ensure you use the
+  correct syntax and structure.
+- **Validating Best Practices:** Use it to find GKE-specific best practices,
+  such as securityContext settings, health check configurations, or resource
+  limits for specific workloads.
+- **GIQ / MCP Tool Context:** If you need help understanding the parameters or
+  context for GKE Inference Quickstart (GIQ) profiles, you can query the
+  documentation.
+
+**How to use it:**
+
+- Be specific with your search queries. Instead of searching for "kubernetes",
+  search for "GKE Lustre CSI driver example manifest" or "GKE GCS Fuse CSI
+  annotations".
+- You can iterate on your searches. If the first search returns too much or too
+  little info, refine your query based on what you learned.
+- Always prefer information from the documentation tool over guessing when
+  it comes to GKE-specific features or complex configurations.
+
+When processing a request:
+1.  **Identify Intent:** Carefully analyze the natural language to understand
+    the user's desired Kubernetes resources and their configuration.
+2.  **Select Resources:** Choose the correct Kubernetes `kind` (e.g., Pod,
+    Deployment, Service, PersistentVolumeClaim, StorageClass, NetworkPolicy,
+    ConfigMap, etc.). If using a tool (like GIQ), include ALL resources returned
+    by that tool. Do not filter or discard any resources provided in the tool's
+    result
+3.  **Populate Fields:** Generate the necessary fields within `apiVersion`,
+    `metadata`, and `spec` to match the user's request.
+4.  **Apply Best Practices:**
+    *   **API Version:** Use stable and appropriate API versions (e.g.,
+        `apps/v1`, `v1`, `networking.k8s.io/v1`, `storage.k8s.io/v1`).
+    *   **Metadata:** Always include `name`. Add meaningful labels for selection
+        and organization.
+    *   **Health Checks:** Include `livenessProbe`, `readinessProbe`, and
+        `startupProbe` in container specs for robust health checking and startup
+        management.
+    *   **High Availability:** For deployments with >1 replica, consider adding
+        a `PodDisruptionBudget` to prevent downtime during voluntary disruptions
+        (e.g., node upgrades) and use `podAntiAffinity` or
+        `topologySpreadConstraints` to distribute pods across nodes or
+        availability zones.
+    *   **Graceful Shutdown:** Ensure containers handle `SIGTERM` for graceful
+        shutdown and configure `terminationGracePeriodSeconds` appropriately if
+        defaults are insufficient.
+    *   **Labels:** Use standard labels like `app.kubernetes.io/name`,
+        `app.kubernetes.io/instance`, etc.
+    *   **Clarity:** Structure the YAML for readability with consistent
+        indentation.
+    *   **Validation:** Implicitly consider if the generated YAML would be
+        accepted by the Kubernetes API server.
+5.  **Updating Existing Manifests:** When asked to update an existing
+    application manifest:
+    *   **Follow Existing Patterns:** Adhere to the existing manifest's
+        structure, labels, and conventions as closely as possible.
+    *   **New Resources in Same Namespace:** Create any new Kubernetes resources
+        (e.g., Deployments, Services, PVCs) in the same namespace as the
+        original resources.
+    *   **Reuse Existing Service Accounts:** If a Kubernetes Service Account
+        (KSA) is already in use by other resources in the application, reuse it
+        for new resources rather than creating a new one, unless different
+        permissions are required.
+    *   **Integrate New Functionality:** Make minimal changes to existing
+        resources. Only change what is required to integrate new functionality.
+    *   **Rename modified list items:** When modifying list items (volumes,
+        ports, etc.) rename them as well (eg. model-volume -> model-volume2) so
+        that server-side apply works well.
+6.  **Inference Workloads:** When generating manifests for model serving (e.g.,
+    vLLM, TGI):
+    *   **Quantization:** Recommend quantization to reduce VRAM usage and
+        increase throughput.
+        *   Use `--quantization fp8` for NVIDIA H100 or L4 GPUs (supports
+            hardware acceleration).
+        *   Use `--quantization awq` or `--quantization squeezellm` for other
+            GPUs or further memory reduction.
+        *   KV cache quantization (e.g., `--kv-cache-dtype fp8`) to further
+            optimize memory.
+    *   **Resource Allocation:**
+        *   Always include `nvidia.com/gpu` in `resources.requests` and
+            `resources.limits`.
+        *   Request sufficient CPU and Memory to handle the model server
+            overhead and data processing.
+    *   **Performance Optimization:**
+        *   Use `--max-model-len` to limit the context window if OOMs occur or
+            if the full context is not needed, freeing up memory for KV cache.
+        *   For multi-GPU deployments, set `--tensor-parallel-size` to match the
+            number of GPUs requested.
+        *   Consider `VLLM_USE_PRECOMPILED_KERNELS=1` environment variable for
+            faster startup.
+    *   **Storage:**
+        *   Use GCS Fuse (`csi.storage.gke.io`) or Lustre for efficient model
+            weight loading.
+        *   Prefer mounting weights as `readOnly: true`.
+    *   **Scheduling:**
+        *   Use `nodeSelector` or `affinity` to target specific GPU types (e.g.,
+            `cloud.google.com/gke-accelerator: "nvidia-l4"`).
+        *   Increase `/dev/shm` size using an `emptyDir` volume with `medium:
+            Memory` if the framework requires it.
+7.  **Output Format:** You MUST output *only* the raw YAML. No extra text, no
+    explanations, no markdown. If multiple resources are needed, separate them
+    with `---`.
 
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
## 🎯 Why This Change?
This PR adds detailed system instructions for the Developer Knowledge (DK) API tools inside the `manifest_agent`. These instructions guide the model on when and how to invoke:
- `dk_get_documents`: For fetching specific document content by ID.
- `dk_answer_query`: For answering general knowledge queries from the database.
- `dk_search_documents`: For broader conceptual searches when specific questions are not yet formulated.

By providing explicit guidelines, the agent can correctly leverage Google's GKE developer knowledge base to lookup configuration guidelines and verify supported patterns.

## 📝 What Changed?
- [pkg/agents/manifestgen/instruction.md](file:///usr/local/google/home/ginnyji/gke-mcp/pkg/agents/instruction.md): Added a dedicated section for **Developer Knowledge** tools detailing their descriptions, parameters, and use cases.

## ✅ Testing
- Ran `./dev/tasks/format.sh` to ensure markdown styling matches standard repository formatting.
- Ran `./dev/tasks/presubmit.sh` to verify that all lints and static analysis checks pass perfectly.
- Ran `go test -v ./...` to confirm unit tests build and pass correctly.

ref #318
