### PR TITLE
feat(k8s): set default cascade policy to background for delete

### DIFF
--- a/pkg/tools/k8s/delete.go
+++ b/pkg/tools/k8s/delete.go
@@ -66,13 +66,9 @@ func (h *handlers) deleteK8SResource(ctx context.Context, _ *mcp.CallToolRequest
 	}
 
 	deleteOptions := metav1.DeleteOptions{}
-	cascade := args.Cascade
-	if cascade == "" {
-		cascade = "background"
-	}
 	var propagationPolicy metav1.DeletionPropagation
-	switch cascade {
-	case "background":
+	switch args.Cascade {
+	case "", "background":
 		propagationPolicy = metav1.DeletePropagationBackground
 	case "foreground":
 		propagationPolicy = metav1.DeletePropagationForeground

--- a/pkg/tools/k8s/delete.go
+++ b/pkg/tools/k8s/delete.go
@@ -66,20 +66,22 @@ func (h *handlers) deleteK8SResource(ctx context.Context, _ *mcp.CallToolRequest
 	}
 
 	deleteOptions := metav1.DeleteOptions{}
-	if args.Cascade != "" {
-		var propagationPolicy metav1.DeletionPropagation
-		switch args.Cascade {
-		case "background":
-			propagationPolicy = metav1.DeletePropagationBackground
-		case "foreground":
-			propagationPolicy = metav1.DeletePropagationForeground
-		case "orphan":
-			propagationPolicy = metav1.DeletePropagationOrphan
-		default:
-			return params.ErrorResult(fmt.Errorf("invalid cascade policy: %s", args.Cascade)), nil, nil
-		}
-		deleteOptions.PropagationPolicy = &propagationPolicy
+	cascade := args.Cascade
+	if cascade == "" {
+		cascade = "background"
 	}
+	var propagationPolicy metav1.DeletionPropagation
+	switch cascade {
+	case "background":
+		propagationPolicy = metav1.DeletePropagationBackground
+	case "foreground":
+		propagationPolicy = metav1.DeletePropagationForeground
+	case "orphan":
+		propagationPolicy = metav1.DeletePropagationOrphan
+	default:
+		return params.ErrorResult(fmt.Errorf("invalid cascade policy: %s", args.Cascade)), nil, nil
+	}
+	deleteOptions.PropagationPolicy = &propagationPolicy
 
 	if args.DryRun {
 		deleteOptions.DryRun = []string{"All"}


### PR DESCRIPTION
# Pull Request

## Why This Change

The user requested to ensure that the `delete_k8s_resource` tool uses 'background' as the default cascade policy when none is specified.

## What Changed

Updated `pkg/tools/k8s/delete.go` to set `DeletePropagationBackground` when the `cascade` argument is empty.

**Files:**

- `pkg/tools/k8s/delete.go`

**Added/Changed/Fixed:**

- Changed: Default cascade policy to 'background' for `delete_k8s_resource`.

## Why This Matters

### 1

- Ensures predictable behavior when cascade policy is omitted, defaulting to background deletion which is standard for most resources.

## Context

https://github.com/GoogleCloudPlatform/gke-mcp/pull/368#discussion_r3289133355

## Testing

```bash
go test -v ./pkg/tools/k8s/... # Pass
```

---