### PR TITLE
feat(k8s): implement list_k8s_api_resources

### DIFF
--- a/pkg/tools/k8s/api_resources.go
+++ b/pkg/tools/k8s/api_resources.go
@@ -64,17 +64,18 @@ func (h *handlers) listK8SAPIResources(ctx context.Context, _ *mcp.CallToolReque
 
 	for _, rl := range resourceLists {
 		gv := rl.GroupVersion
+		
+		// Find group name
+		parts := strings.Split(gv, "/")
+		var group string
+		if len(parts) == 2 {
+			group = parts[0]
+		}
+
 		for _, r := range rl.APIResources {
 			if strings.Contains(r.Name, "/") {
 				// Skip subresources like pods/log
 				continue
-			}
-
-			// Find group name
-			parts := strings.Split(gv, "/")
-			var group string
-			if len(parts) == 2 {
-				group = parts[0]
 			}
 
 			key := resourceKey{name: r.Name, group: group}

--- a/pkg/tools/k8s/api_resources.go
+++ b/pkg/tools/k8s/api_resources.go
@@ -64,7 +64,7 @@ func (h *handlers) listK8SAPIResources(ctx context.Context, _ *mcp.CallToolReque
 
 	for _, rl := range resourceLists {
 		gv := rl.GroupVersion
-		
+
 		// Find group name
 		parts := strings.Split(gv, "/")
 		var group string

--- a/pkg/tools/k8s/api_resources.go
+++ b/pkg/tools/k8s/api_resources.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/params"
@@ -28,6 +29,7 @@ type listK8SAPIResourcesArgs struct {
 	params.Cluster
 }
 
+// APIGroupDiscovery represents a discovery document for an API group/resource.
 type APIGroupDiscovery struct {
 	Name             string   `json:"name"`
 	Versions         []string `json:"versions"`
@@ -47,8 +49,12 @@ func (h *handlers) listK8SAPIResources(ctx context.Context, _ *mcp.CallToolReque
 		return params.ErrorResult(fmt.Errorf("failed to get server groups and resources: %w", err)), nil, nil
 	}
 
-	resourceVersions := make(map[string][]string)
-	resourcePreferredVersion := make(map[string]string)
+	type resourceKey struct {
+		name  string
+		group string
+	}
+	resourceMap := make(map[resourceKey][]string)
+	resourcePrefMap := make(map[resourceKey]string)
 
 	// Map group name to preferred version
 	prefVersions := make(map[string]string)
@@ -63,7 +69,6 @@ func (h *handlers) listK8SAPIResources(ctx context.Context, _ *mcp.CallToolReque
 				// Skip subresources like pods/log
 				continue
 			}
-			resourceVersions[r.Name] = append(resourceVersions[r.Name], gv)
 
 			// Find group name
 			parts := strings.Split(gv, "/")
@@ -72,22 +77,33 @@ func (h *handlers) listK8SAPIResources(ctx context.Context, _ *mcp.CallToolReque
 				group = parts[0]
 			}
 
+			key := resourceKey{name: r.Name, group: group}
+			resourceMap[key] = append(resourceMap[key], gv)
+
 			pref := prefVersions[group]
 			if pref == "" {
 				pref = "v1" // fallback for core group
 			}
-			resourcePreferredVersion[r.Name] = pref
+			resourcePrefMap[key] = pref
 		}
 	}
 
 	var resources []APIGroupDiscovery
-	for name, versions := range resourceVersions {
+	for k, versions := range resourceMap {
 		resources = append(resources, APIGroupDiscovery{
-			Name:             name,
+			Name:             k.name,
 			Versions:         versions,
-			PreferredVersion: resourcePreferredVersion[name],
+			PreferredVersion: resourcePrefMap[k],
 		})
 	}
+
+	// Sort resources by name to ensure deterministic output
+	sort.Slice(resources, func(i, j int) bool {
+		if resources[i].Name != resources[j].Name {
+			return resources[i].Name < resources[j].Name
+		}
+		return resources[i].PreferredVersion < resources[j].PreferredVersion
+	})
 
 	data, err := json.MarshalIndent(resources, "", "  ")
 	if err != nil {

--- a/pkg/tools/k8s/api_resources.go
+++ b/pkg/tools/k8s/api_resources.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/params"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type listK8SAPIResourcesArgs struct {
+	params.Cluster
+}
+
+type APIGroupDiscovery struct {
+	Name             string   `json:"name"`
+	Versions         []string `json:"versions"`
+	PreferredVersion string   `json:"preferred_version"`
+}
+
+func (h *handlers) listK8SAPIResources(ctx context.Context, _ *mcp.CallToolRequest, args *listK8SAPIResourcesArgs) (*mcp.CallToolResult, any, error) {
+	clusterPath := args.ClusterPath()
+
+	discoveryClient, err := h.provider.DiscoveryClient(ctx, clusterPath)
+	if err != nil {
+		return params.ErrorResult(fmt.Errorf("failed to get discovery client: %w", err)), nil, nil
+	}
+
+	groups, resourceLists, err := discoveryClient.ServerGroupsAndResources()
+	if err != nil {
+		return params.ErrorResult(fmt.Errorf("failed to get server groups and resources: %w", err)), nil, nil
+	}
+
+	resourceVersions := make(map[string][]string)
+	resourcePreferredVersion := make(map[string]string)
+
+	// Map group name to preferred version
+	prefVersions := make(map[string]string)
+	for _, g := range groups {
+		prefVersions[g.Name] = g.PreferredVersion.GroupVersion
+	}
+
+	for _, rl := range resourceLists {
+		gv := rl.GroupVersion
+		for _, r := range rl.APIResources {
+			if strings.Contains(r.Name, "/") {
+				// Skip subresources like pods/log
+				continue
+			}
+			resourceVersions[r.Name] = append(resourceVersions[r.Name], gv)
+
+			// Find group name
+			parts := strings.Split(gv, "/")
+			var group string
+			if len(parts) == 2 {
+				group = parts[0]
+			}
+
+			pref := prefVersions[group]
+			if pref == "" {
+				pref = "v1" // fallback for core group
+			}
+			resourcePreferredVersion[r.Name] = pref
+		}
+	}
+
+	var resources []APIGroupDiscovery
+	for name, versions := range resourceVersions {
+		resources = append(resources, APIGroupDiscovery{
+			Name:             name,
+			Versions:         versions,
+			PreferredVersion: resourcePreferredVersion[name],
+		})
+	}
+
+	data, err := json.MarshalIndent(resources, "", "  ")
+	if err != nil {
+		return params.ErrorResult(fmt.Errorf("failed to marshal result: %w", err)), nil, nil
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(data)},
+		},
+	}, nil, nil
+}

--- a/pkg/tools/k8s/api_resources.go
+++ b/pkg/tools/k8s/api_resources.go
@@ -102,7 +102,14 @@ func (h *handlers) listK8SAPIResources(ctx context.Context, _ *mcp.CallToolReque
 		if resources[i].Name != resources[j].Name {
 			return resources[i].Name < resources[j].Name
 		}
-		return resources[i].PreferredVersion < resources[j].PreferredVersion
+		if resources[i].PreferredVersion != resources[j].PreferredVersion {
+			return resources[i].PreferredVersion < resources[j].PreferredVersion
+		}
+		// Fallback to sorting by the first version to ensure determinism
+		if len(resources[i].Versions) > 0 && len(resources[j].Versions) > 0 {
+			return resources[i].Versions[0] < resources[j].Versions[0]
+		}
+		return false
 	})
 
 	data, err := json.MarshalIndent(resources, "", "  ")

--- a/pkg/tools/k8s/api_resources_test.go
+++ b/pkg/tools/k8s/api_resources_test.go
@@ -91,15 +91,15 @@ func TestListK8SAPIResources(t *testing.T) {
 
 	// Verify content (assuming sorted by name)
 	// Expected order: deployments, pods, pods
-	
+
 	if resources[0].Name != "deployments" {
 		t.Errorf("resources[0].Name = %s, want deployments", resources[0].Name)
 	}
-	
+
 	// We expect pods to be at index 1 and 2.
 	foundCorePods := false
 	foundCustomPods := false
-	
+
 	for i := 1; i <= 2; i++ {
 		r := resources[i]
 		if r.Name != "pods" {
@@ -117,7 +117,7 @@ func TestListK8SAPIResources(t *testing.T) {
 			foundCustomPods = true
 		}
 	}
-	
+
 	if !foundCorePods {
 		t.Errorf("core pods (v1) not found at index 1 or 2")
 	}

--- a/pkg/tools/k8s/api_resources_test.go
+++ b/pkg/tools/k8s/api_resources_test.go
@@ -44,6 +44,12 @@ func TestListK8SAPIResources(t *testing.T) {
 				{Name: "deployments", Namespaced: true, Kind: "Deployment"},
 			},
 		},
+		{
+			GroupVersion: "custom.example.com/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", Namespaced: true, Kind: "CustomPod"},
+			},
+		},
 	}
 
 	mockProvider := &mockClientProvider{
@@ -79,38 +85,43 @@ func TestListK8SAPIResources(t *testing.T) {
 		t.Fatalf("failed to unmarshal result: %v", err)
 	}
 
-	if len(resources) != 2 {
-		t.Fatalf("len(resources) = %d, want 2", len(resources))
+	if len(resources) != 3 {
+		t.Fatalf("len(resources) = %d, want 3", len(resources))
 	}
 
-	// Verify content
-	foundPods := false
-	foundDeployments := false
-	for _, r := range resources {
-		if r.Name == "pods" {
-			foundPods = true
-			if len(r.Versions) != 1 || r.Versions[0] != "v1" {
-				t.Errorf("pods versions = %v, want [v1]", r.Versions)
-			}
-			if r.PreferredVersion != "v1" {
-				t.Errorf("pods preferredVersion = %s, want v1", r.PreferredVersion)
-			}
+	// Verify content (assuming sorted by name)
+	// Expected order: deployments, pods, pods
+	
+	if resources[0].Name != "deployments" {
+		t.Errorf("resources[0].Name = %s, want deployments", resources[0].Name)
+	}
+	
+	// We expect pods to be at index 1 and 2.
+	foundCorePods := false
+	foundCustomPods := false
+	
+	for i := 1; i <= 2; i++ {
+		r := resources[i]
+		if r.Name != "pods" {
+			t.Errorf("resources[%d].Name = %s, want pods", i, r.Name)
+			continue
 		}
-		if r.Name == "deployments" {
-			foundDeployments = true
-			if len(r.Versions) != 1 || r.Versions[0] != "apps/v1" {
-				t.Errorf("deployments versions = %v, want [apps/v1]", r.Versions)
-			}
-			if r.PreferredVersion != "apps/v1" {
-				t.Errorf("deployments preferredVersion = %s, want apps/v1", r.PreferredVersion)
-			}
+		if len(r.Versions) != 1 {
+			t.Errorf("resources[%d].Versions length = %d, want 1", i, len(r.Versions))
+			continue
+		}
+		if r.Versions[0] == "v1" {
+			foundCorePods = true
+		}
+		if r.Versions[0] == "custom.example.com/v1" {
+			foundCustomPods = true
 		}
 	}
-
-	if !foundPods {
-		t.Errorf("pods not found in result")
+	
+	if !foundCorePods {
+		t.Errorf("core pods (v1) not found at index 1 or 2")
 	}
-	if !foundDeployments {
-		t.Errorf("deployments not found in result")
+	if !foundCustomPods {
+		t.Errorf("custom pods (custom.example.com/v1) not found at index 1 or 2")
 	}
 }

--- a/pkg/tools/k8s/api_resources_test.go
+++ b/pkg/tools/k8s/api_resources_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestListK8SAPIResources(t *testing.T) {
+	ctx := context.Background()
+
+	fakeClientset := fake.NewSimpleClientset()
+	fakeDiscovery := fakeClientset.Discovery().(*fakediscovery.FakeDiscovery)
+	fakeDiscovery.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", Namespaced: true, Kind: "Pod"},
+			},
+		},
+		{
+			GroupVersion: "apps/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "deployments", Namespaced: true, Kind: "Deployment"},
+			},
+		},
+	}
+
+	mockProvider := &mockClientProvider{
+		discoveryClient: fakeDiscovery,
+	}
+
+	h := &handlers{
+		c:        &config.Config{},
+		provider: mockProvider,
+	}
+
+	args := &listK8SAPIResourcesArgs{}
+	args.ProjectID = "p"
+	args.Location = "l"
+	args.ClusterName = "c"
+
+	result, _, err := h.listK8SAPIResources(ctx, &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatalf("listK8SAPIResources failed: %v", err)
+	}
+
+	if result.IsError {
+		t.Fatalf("listK8SAPIResources returned error result: %v", result.Content[0])
+	}
+
+	textContent, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("result.Content[0] is not TextContent")
+	}
+
+	var resources []APIGroupDiscovery
+	if err := json.Unmarshal([]byte(textContent.Text), &resources); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	if len(resources) != 2 {
+		t.Fatalf("len(resources) = %d, want 2", len(resources))
+	}
+
+	// Verify content
+	foundPods := false
+	foundDeployments := false
+	for _, r := range resources {
+		if r.Name == "pods" {
+			foundPods = true
+			if len(r.Versions) != 1 || r.Versions[0] != "v1" {
+				t.Errorf("pods versions = %v, want [v1]", r.Versions)
+			}
+			if r.PreferredVersion != "v1" {
+				t.Errorf("pods preferredVersion = %s, want v1", r.PreferredVersion)
+			}
+		}
+		if r.Name == "deployments" {
+			foundDeployments = true
+			if len(r.Versions) != 1 || r.Versions[0] != "apps/v1" {
+				t.Errorf("deployments versions = %v, want [apps/v1]", r.Versions)
+			}
+			if r.PreferredVersion != "apps/v1" {
+				t.Errorf("deployments preferredVersion = %s, want apps/v1", r.PreferredVersion)
+			}
+		}
+	}
+
+	if !foundPods {
+		t.Errorf("pods not found in result")
+	}
+	if !foundDeployments {
+		t.Errorf("deployments not found in result")
+	}
+}

--- a/pkg/tools/k8s/tools.go
+++ b/pkg/tools/k8s/tools.go
@@ -51,6 +51,14 @@ func Install(_ context.Context, s *mcp.Server, c *config.Config) error {
 	}, h.listK8SEvents)
 
 	mcp.AddTool(s, &mcp.Tool{
+		Name:        "list_k8s_api_resources",
+		Description: "Retrieves the available API groups and resources from a Kubernetes cluster. This is similar to running `kubectl api-resources`.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+	}, h.listK8SAPIResources)
+
+	mcp.AddTool(s, &mcp.Tool{
 		Name:        "get_k8s_version",
 		Description: "Retrieves the Kubernetes server version for a given cluster. This is similar to running kubectl version.",
 		Annotations: &mcp.ToolAnnotations{


### PR DESCRIPTION
# Pull Request

## Why This Change

Implement `list_k8s_api_resources` to match the hosted service functionality.

## What Changed

Added `list_k8s_api_resources` tool to list available API groups and resources.

**Files:**

- `pkg/tools/k8s/api_resources.go`
- `pkg/tools/k8s/api_resources_test.go`
- `pkg/tools/k8s/tools.go`

**Added/Changed/Fixed:**

- Added `list_k8s_api_resources` tool.

## Why This Matters

Provides parity with the hosted service.

## Context

Requested by user in chat.

## Testing

```bash
go test -v ./pkg/tools/k8s/... # Pass
```

---
