### PR TITLE
feat(k8s): implement get_k8s_cluster_info

### DIFF
--- a/pkg/tools/k8s/cluster_info.go
+++ b/pkg/tools/k8s/cluster_info.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/params"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type getK8SClusterInfoArgs struct {
+	params.Cluster
+}
+
+func (h *handlers) getK8SClusterInfo(ctx context.Context, _ *mcp.CallToolRequest, args *getK8SClusterInfoArgs) (*mcp.CallToolResult, any, error) {
+	clusterPath := args.ClusterPath()
+
+	config, err := h.provider.RESTConfig(ctx, clusterPath)
+	if err != nil {
+		return params.ErrorResult(fmt.Errorf("failed to get REST config: %w", err)), nil, nil
+	}
+
+	client, err := h.provider.KubernetesClient(ctx, clusterPath)
+	if err != nil {
+		return params.ErrorResult(fmt.Errorf("failed to get kubernetes client: %w", err)), nil, nil
+	}
+
+	var result strings.Builder
+	result.WriteString(fmt.Sprintf("Kubernetes control plane is at %s\n", config.Host))
+
+	// Try to find CoreDNS or kube-dns
+	_, err = client.CoreV1().Services("kube-system").Get(ctx, "kube-dns", metav1.GetOptions{})
+	if err == nil {
+		result.WriteString(fmt.Sprintf("CoreDNS is running at %s/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy\n", config.Host))
+	} else {
+		// try coredns name
+		_, err = client.CoreV1().Services("kube-system").Get(ctx, "coredns", metav1.GetOptions{})
+		if err == nil {
+			result.WriteString(fmt.Sprintf("CoreDNS is running at %s/api/v1/namespaces/kube-system/services/coredns:dns/proxy\n", config.Host))
+		}
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: result.String()},
+		},
+	}, nil, nil
+}

--- a/pkg/tools/k8s/cluster_info.go
+++ b/pkg/tools/k8s/cluster_info.go
@@ -50,11 +50,12 @@ func (h *handlers) getK8SClusterInfo(ctx context.Context, _ *mcp.CallToolRequest
 		return params.ErrorResult(fmt.Errorf("failed to list services: %w", err)), nil, nil
 	}
 
+	host := strings.TrimSuffix(config.Host, "/")
 	var lines []string
-	lines = append(lines, fmt.Sprintf("Kubernetes control plane is running at %s", config.Host))
+	lines = append(lines, fmt.Sprintf("Kubernetes control plane is running at %s", host))
 
 	for _, s := range services.Items {
-		lines = append(lines, fmt.Sprintf("%s is running at %s", serviceName(s), serviceLink(s, config.Host)))
+		lines = append(lines, fmt.Sprintf("%s is running at %s", serviceName(s), serviceLink(s, host)))
 	}
 
 	return &mcp.CallToolResult{
@@ -78,13 +79,13 @@ func serviceLink(s corev1.Service, host string) string {
 		if ip == "" {
 			ip = ingress.Hostname
 		}
-		var link strings.Builder
+		var links []string
 		for _, port := range s.Spec.Ports {
-			link.WriteString("http://" + ip + ":" + strconv.Itoa(int(port.Port)))
+			links = append(links, "http://"+ip+":"+strconv.Itoa(int(port.Port)))
 		}
-		return link.String()
+		return strings.Join(links, ", ")
 	}
-	return host + "/api/v1/namespaces/" + s.Namespace + "/services/" + serviceProxyResourceName(s) + "/proxy"
+	return strings.TrimSuffix(host, "/") + "/api/v1/namespaces/" + s.Namespace + "/services/" + serviceProxyResourceName(s) + "/proxy"
 }
 
 func serviceProxyResourceName(service corev1.Service) string {
@@ -97,7 +98,7 @@ func serviceProxyResourceName(service corev1.Service) string {
 		if len(port.Name) > 0 {
 			return serviceName + ":" + port.Name
 		}
-		return serviceName
+		return serviceName + ":" + strconv.Itoa(int(port.Port))
 	}
 	return service.Name
 }

--- a/pkg/tools/k8s/cluster_info.go
+++ b/pkg/tools/k8s/cluster_info.go
@@ -81,7 +81,11 @@ func serviceLink(s corev1.Service, host string) string {
 		}
 		var links []string
 		for _, port := range s.Spec.Ports {
-			links = append(links, "http://"+ip+":"+strconv.Itoa(int(port.Port)))
+			scheme := guessScheme(port)
+			if scheme == "" {
+				scheme = "http"
+			}
+			links = append(links, scheme+"://"+ip+":"+strconv.Itoa(int(port.Port)))
 		}
 		return strings.Join(links, ", ")
 	}

--- a/pkg/tools/k8s/cluster_info.go
+++ b/pkg/tools/k8s/cluster_info.go
@@ -17,10 +17,12 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/params"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -41,24 +43,68 @@ func (h *handlers) getK8SClusterInfo(ctx context.Context, _ *mcp.CallToolRequest
 		return params.ErrorResult(fmt.Errorf("failed to get kubernetes client: %w", err)), nil, nil
 	}
 
-	var result strings.Builder
-	result.WriteString(fmt.Sprintf("Kubernetes control plane is at %s\n", config.Host))
+	services, err := client.CoreV1().Services("kube-system").List(ctx, metav1.ListOptions{
+		LabelSelector: "kubernetes.io/cluster-service=true",
+	})
+	if err != nil {
+		return params.ErrorResult(fmt.Errorf("failed to list services: %w", err)), nil, nil
+	}
 
-	// Try to find CoreDNS or kube-dns
-	_, err = client.CoreV1().Services("kube-system").Get(ctx, "kube-dns", metav1.GetOptions{})
-	if err == nil {
-		result.WriteString(fmt.Sprintf("CoreDNS is running at %s/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy\n", config.Host))
-	} else {
-		// try coredns name
-		_, err = client.CoreV1().Services("kube-system").Get(ctx, "coredns", metav1.GetOptions{})
-		if err == nil {
-			result.WriteString(fmt.Sprintf("CoreDNS is running at %s/api/v1/namespaces/kube-system/services/coredns:dns/proxy\n", config.Host))
-		}
+	var lines []string
+	lines = append(lines, fmt.Sprintf("Kubernetes control plane is running at %s", config.Host))
+
+	for _, s := range services.Items {
+		lines = append(lines, fmt.Sprintf("%s is running at %s", serviceName(s), serviceLink(s, config.Host)))
 	}
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
-			&mcp.TextContent{Text: result.String()},
+			&mcp.TextContent{Text: strings.Join(lines, "\n")},
 		},
 	}, nil, nil
+}
+
+func serviceName(s corev1.Service) string {
+	if name, found := s.ObjectMeta.GetLabels()["kubernetes.io/name"]; found {
+		return name
+	}
+	return s.ObjectMeta.GetName()
+}
+
+func serviceLink(s corev1.Service, host string) string {
+	if len(s.Status.LoadBalancer.Ingress) > 0 {
+		ingress := s.Status.LoadBalancer.Ingress[0]
+		ip := ingress.IP
+		if ip == "" {
+			ip = ingress.Hostname
+		}
+		var link strings.Builder
+		for _, port := range s.Spec.Ports {
+			link.WriteString("http://" + ip + ":" + strconv.Itoa(int(port.Port)))
+		}
+		return link.String()
+	}
+	return host + "/api/v1/namespaces/" + s.ObjectMeta.Namespace + "/services/" + serviceProxyResourceName(s) + "/proxy"
+}
+
+func serviceProxyResourceName(service corev1.Service) string {
+	serviceName := service.ObjectMeta.Name
+	if len(service.Spec.Ports) > 0 {
+		port := service.Spec.Ports[0]
+		if scheme := guessScheme(port); len(scheme) > 0 {
+			return scheme + ":" + serviceName + ":" + port.Name
+		}
+		if len(port.Name) > 0 {
+			return serviceName + ":" + port.Name
+		}
+		return serviceName
+	}
+	return service.ObjectMeta.Name
+}
+
+func guessScheme(port corev1.ServicePort) string {
+	if port.Name == "https" || port.Port == 443 {
+		return "https"
+	}
+	return ""
 }

--- a/pkg/tools/k8s/cluster_info.go
+++ b/pkg/tools/k8s/cluster_info.go
@@ -65,10 +65,10 @@ func (h *handlers) getK8SClusterInfo(ctx context.Context, _ *mcp.CallToolRequest
 }
 
 func serviceName(s corev1.Service) string {
-	if name, found := s.ObjectMeta.GetLabels()["kubernetes.io/name"]; found {
+	if name, found := s.GetLabels()["kubernetes.io/name"]; found {
 		return name
 	}
-	return s.ObjectMeta.GetName()
+	return s.GetName()
 }
 
 func serviceLink(s corev1.Service, host string) string {
@@ -84,11 +84,11 @@ func serviceLink(s corev1.Service, host string) string {
 		}
 		return link.String()
 	}
-	return host + "/api/v1/namespaces/" + s.ObjectMeta.Namespace + "/services/" + serviceProxyResourceName(s) + "/proxy"
+	return host + "/api/v1/namespaces/" + s.Namespace + "/services/" + serviceProxyResourceName(s) + "/proxy"
 }
 
 func serviceProxyResourceName(service corev1.Service) string {
-	serviceName := service.ObjectMeta.Name
+	serviceName := service.Name
 	if len(service.Spec.Ports) > 0 {
 		port := service.Spec.Ports[0]
 		if scheme := guessScheme(port); len(scheme) > 0 {
@@ -99,7 +99,7 @@ func serviceProxyResourceName(service corev1.Service) string {
 		}
 		return serviceName
 	}
-	return service.ObjectMeta.Name
+	return service.Name
 }
 
 func guessScheme(port corev1.ServicePort) string {

--- a/pkg/tools/k8s/cluster_info_test.go
+++ b/pkg/tools/k8s/cluster_info_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+)
+
+func TestGetK8SClusterInfo(t *testing.T) {
+	ctx := context.Background()
+
+	fakeClientset := fake.NewSimpleClientset(&corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-dns",
+			Namespace: "kube-system",
+		},
+	})
+
+	mockProvider := &mockClientProvider{
+		kubernetesClient: fakeClientset,
+		restConfig:       &rest.Config{Host: "https://10.0.0.1"},
+	}
+
+	h := &handlers{
+		c:        &config.Config{},
+		provider: mockProvider,
+	}
+
+	args := &getK8SClusterInfoArgs{}
+	args.ProjectID = "p"
+	args.Location = "l"
+	args.ClusterName = "c"
+
+	result, _, err := h.getK8SClusterInfo(ctx, &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatalf("getK8SClusterInfo failed: %v", err)
+	}
+
+	if result.IsError {
+		t.Fatalf("getK8SClusterInfo returned error result: %v", result.Content[0])
+	}
+
+	textContent, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("result.Content[0] is not TextContent")
+	}
+
+	if !strings.Contains(textContent.Text, "Kubernetes control plane is at https://10.0.0.1") {
+		t.Errorf("output does not contain control plane info")
+	}
+
+	if !strings.Contains(textContent.Text, "CoreDNS is running at https://10.0.0.1/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy") {
+		t.Errorf("output does not contain CoreDNS info")
+	}
+}

--- a/pkg/tools/k8s/cluster_info_test.go
+++ b/pkg/tools/k8s/cluster_info_test.go
@@ -34,6 +34,15 @@ func TestGetK8SClusterInfo(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kube-dns",
 			Namespace: "kube-system",
+			Labels: map[string]string{
+				"kubernetes.io/cluster-service": "true",
+				"kubernetes.io/name":            "CoreDNS",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "dns", Port: 53},
+			},
 		},
 	})
 
@@ -66,7 +75,7 @@ func TestGetK8SClusterInfo(t *testing.T) {
 		t.Fatalf("result.Content[0] is not TextContent")
 	}
 
-	if !strings.Contains(textContent.Text, "Kubernetes control plane is at https://10.0.0.1") {
+	if !strings.Contains(textContent.Text, "Kubernetes control plane is running at https://10.0.0.1") {
 		t.Errorf("output does not contain control plane info")
 	}
 

--- a/pkg/tools/k8s/tools.go
+++ b/pkg/tools/k8s/tools.go
@@ -59,6 +59,14 @@ func Install(_ context.Context, s *mcp.Server, c *config.Config) error {
 	}, h.getK8SVersion)
 
 	mcp.AddTool(s, &mcp.Tool{
+		Name:        "get_k8s_cluster_info",
+		Description: "Gets cluster endpoint information. This is similar to running `kubectl cluster-info`.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+	}, h.getK8SClusterInfo)
+
+	mcp.AddTool(s, &mcp.Tool{
 		Name:        "apply_k8s_manifest",
 		Description: "Applies a Kubernetes manifest to a cluster using server-side apply. This is similar to running `kubectl apply --server-side`.",
 	}, h.applyK8SManifest)


### PR DESCRIPTION
# Pull Request

## Why This Change

Implement `get_k8s_cluster_info` to match the hosted service functionality.

## What Changed

Added `get_k8s_cluster_info` tool to retrieve cluster endpoint and core service information.

**Files:**

- `pkg/tools/k8s/cluster_info.go`
- `pkg/tools/k8s/cluster_info_test.go`
- `pkg/tools/k8s/tools.go`

**Added/Changed/Fixed:**

- Added `get_k8s_cluster_info` tool.

## Why This Matters

Provides parity with the hosted service.

## Context

Requested by user in chat.

## Testing

```bash
go test -v ./pkg/tools/k8s/... # Pass
```

---
