### PR TITLE
docs: add self code-review note to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ updated `ui/dist/apps/*/index.html` files in the same change.
 
 ## Pull Request Hygiene
 
+- Perform a local code-review before sending or updating PRs.
 - Keep changes scoped to the request.
 - Do not commit unrelated formatting or generated output.
 - Use Conventional Commits for commit messages.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ updated `ui/dist/apps/*/index.html` files in the same change.
 
 ## Pull Request Hygiene
 
-- Perform a local code-review before sending or updating PRs.
+- Perform a self-review of the changes before sending or updating PRs.
 - Keep changes scoped to the request.
 - Do not commit unrelated formatting or generated output.
 - Use Conventional Commits for commit messages.


### PR DESCRIPTION
# Pull Request

## Why This Change

Add a reminder to perform a self code-review before sending or updating PRs, as requested by the user.

## What Changed

Added a bullet point to `AGENTS.md` in the "Pull Request Hygiene" section.

**Files:**

- `AGENTS.md`

**Added/Changed/Fixed:**

- Added: "- Do a self code-review before sending / updating PRs."

## Why This Matters

### 1

Encourages better code quality and reduces review iterations.

## Context

User request.

## Testing

```bash
./dev/tasks/presubmit.sh  # Pass
```

Ran `./dev/tasks/presubmit.sh` and it passed. Also ran `npx prettier --write AGENTS.md`.
