### PR TITLE
feat(k8s): add describe_k8s_resource tool

### DIFF
--- a/pkg/tools/k8s/describe.go
+++ b/pkg/tools/k8s/describe.go
@@ -118,15 +118,15 @@ func (h *handlers) describeK8SResource(ctx context.Context, _ *mcp.CallToolReque
 
 func (h *handlers) describeObject(ctx context.Context, obj *unstructured.Unstructured, kind string, isNamespaced bool, cluster params.Cluster) (string, error) {
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("Name: %s\n", obj.GetName()))
-	sb.WriteString(fmt.Sprintf("Namespace: %s\n", obj.GetNamespace()))
-	sb.WriteString(fmt.Sprintf("Kind: %s\n", kind))
+	fmt.Fprintf(&sb, "Name: %s\n", obj.GetName())
+	fmt.Fprintf(&sb, "Namespace: %s\n", obj.GetNamespace())
+	fmt.Fprintf(&sb, "Kind: %s\n", kind)
 
 	labels := obj.GetLabels()
 	if len(labels) > 0 {
 		sb.WriteString("Labels:\n")
 		for k, v := range labels {
-			sb.WriteString(fmt.Sprintf("  %s=%s\n", k, v))
+			fmt.Fprintf(&sb, "  %s=%s\n", k, v)
 		}
 	}
 
@@ -134,7 +134,7 @@ func (h *handlers) describeObject(ctx context.Context, obj *unstructured.Unstruc
 	if len(annotations) > 0 {
 		sb.WriteString("Annotations:\n")
 		for k, v := range annotations {
-			sb.WriteString(fmt.Sprintf("  %s=%s\n", k, v))
+			fmt.Fprintf(&sb, "  %s=%s\n", k, v)
 		}
 	}
 

--- a/pkg/tools/k8s/describe.go
+++ b/pkg/tools/k8s/describe.go
@@ -1,0 +1,175 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/params"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	"sigs.k8s.io/yaml"
+)
+
+type describeK8SResourceArgs struct {
+	params.Cluster
+	ResourceType  string `json:"resourceType" jsonschema:"Required. The type of the resource. e.g. \"pods\", \"deployments\", \"services\"."`
+	Name          string `json:"name,omitempty" jsonschema:"Optional. The name of the resource. If not specified, all resources of the given type are described."`
+	Namespace     string `json:"namespace,omitempty" jsonschema:"Optional. The namespace of the resource. If not specified, \"default\" is used for namespace-scoped resources."`
+	LabelSelector string `json:"labelSelector,omitempty" jsonschema:"Optional. A label selector to filter resources."`
+}
+
+func (h *handlers) describeK8SResource(ctx context.Context, _ *mcp.CallToolRequest, args *describeK8SResourceArgs) (*mcp.CallToolResult, any, error) {
+	if args == nil {
+		return params.ErrorResult(fmt.Errorf("args cannot be nil")), nil, nil
+	}
+	clusterPath := args.ClusterPath()
+
+	discoveryClient, err := h.provider.DiscoveryClient(ctx, clusterPath)
+	if err != nil {
+		return params.ErrorResult(fmt.Errorf("failed to get discovery client: %w", err)), nil, nil
+	}
+
+	gvr, gvk, isNamespaced, err := ResolveGVR(ctx, discoveryClient, args.ResourceType)
+	if err != nil {
+		return params.ErrorResult(err), nil, nil
+	}
+
+	namespace := args.Namespace
+	if isNamespaced && namespace == "" {
+		namespace = "default"
+	}
+
+	dynamicClient, err := h.provider.DynamicClient(ctx, clusterPath)
+	if err != nil {
+		return params.ErrorResult(fmt.Errorf("failed to get dynamic client: %w", err)), nil, nil
+	}
+
+	var resourceInterface dynamic.ResourceInterface
+	if isNamespaced {
+		resourceInterface = dynamicClient.Resource(gvr).Namespace(namespace)
+	} else {
+		resourceInterface = dynamicClient.Resource(gvr)
+	}
+
+	var resultBuilder strings.Builder
+
+	if args.Name != "" {
+		obj, err := resourceInterface.Get(ctx, args.Name, metav1.GetOptions{})
+		if err != nil {
+			return params.ErrorResult(fmt.Errorf("failed to get resource: %w", err)), nil, nil
+		}
+
+		desc, err := h.describeObject(ctx, obj, gvk.Kind, args.Cluster)
+		if err != nil {
+			return params.ErrorResult(err), nil, nil
+		}
+		resultBuilder.WriteString(desc)
+	} else {
+		list, err := resourceInterface.List(ctx, metav1.ListOptions{
+			LabelSelector: args.LabelSelector,
+		})
+		if err != nil {
+			return params.ErrorResult(fmt.Errorf("failed to list resources: %w", err)), nil, nil
+		}
+
+		for i, item := range list.Items {
+			desc, err := h.describeObject(ctx, &item, gvk.Kind, args.Cluster)
+			if err != nil {
+				return params.ErrorResult(err), nil, nil
+			}
+			resultBuilder.WriteString(desc)
+			if i < len(list.Items)-1 {
+				resultBuilder.WriteString("\n---\n")
+			}
+		}
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: resultBuilder.String()},
+		},
+	}, nil, nil
+}
+
+func (h *handlers) describeObject(ctx context.Context, obj *unstructured.Unstructured, kind string, cluster params.Cluster) (string, error) {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Name: %s\n", obj.GetName()))
+	sb.WriteString(fmt.Sprintf("Namespace: %s\n", obj.GetNamespace()))
+	sb.WriteString(fmt.Sprintf("Kind: %s\n", kind))
+
+	labels := obj.GetLabels()
+	if len(labels) > 0 {
+		sb.WriteString("Labels:\n")
+		for k, v := range labels {
+			sb.WriteString(fmt.Sprintf("  %s=%s\n", k, v))
+		}
+	}
+
+	annotations := obj.GetAnnotations()
+	if len(annotations) > 0 {
+		sb.WriteString("Annotations:\n")
+		for k, v := range annotations {
+			sb.WriteString(fmt.Sprintf("  %s=%s\n", k, v))
+		}
+	}
+
+	// Show spec and status as YAML
+	spec, ok := obj.Object["spec"]
+	if ok {
+		specYAML, _ := yaml.Marshal(spec)
+		sb.WriteString("Spec:\n")
+		sb.WriteString(indent(string(specYAML), "  "))
+	}
+
+	status, ok := obj.Object["status"]
+	if ok {
+		statusYAML, _ := yaml.Marshal(status)
+		sb.WriteString("Status:\n")
+		sb.WriteString(indent(string(statusYAML), "  "))
+	}
+
+	// Fetch events
+	eventsResult, _, err := h.listK8SEvents(ctx, nil, &listK8SEventsArgs{
+		Cluster:      cluster,
+		Name:         obj.GetName(),
+		Namespace:    obj.GetNamespace(),
+		ResourceType: kind,
+	})
+
+	if err == nil && !eventsResult.IsError && len(eventsResult.Content) > 0 {
+		textContent, ok := eventsResult.Content[0].(*mcp.TextContent)
+		if ok && textContent.Text != "" {
+			sb.WriteString("\nEvents:\n")
+			sb.WriteString(indent(textContent.Text, "  "))
+		}
+	}
+
+	return sb.String(), nil
+}
+
+func indent(s, prefix string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		if line != "" {
+			lines[i] = prefix + line
+		}
+	}
+	return strings.Join(lines, "\n")
+}

--- a/pkg/tools/k8s/describe.go
+++ b/pkg/tools/k8s/describe.go
@@ -76,7 +76,7 @@ func (h *handlers) describeK8SResource(ctx context.Context, _ *mcp.CallToolReque
 			return params.ErrorResult(fmt.Errorf("failed to get resource: %w", err)), nil, nil
 		}
 
-		desc, err := h.describeObject(ctx, obj, gvk.Kind, args.Cluster)
+		desc, err := h.describeObject(ctx, obj, gvk.Kind, isNamespaced, args.Cluster)
 		if err != nil {
 			return params.ErrorResult(err), nil, nil
 		}
@@ -89,8 +89,16 @@ func (h *handlers) describeK8SResource(ctx context.Context, _ *mcp.CallToolReque
 			return params.ErrorResult(fmt.Errorf("failed to list resources: %w", err)), nil, nil
 		}
 
+		if len(list.Items) == 0 {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: "No resources found."},
+				},
+			}, nil, nil
+		}
+
 		for i, item := range list.Items {
-			desc, err := h.describeObject(ctx, &item, gvk.Kind, args.Cluster)
+			desc, err := h.describeObject(ctx, &item, gvk.Kind, isNamespaced, args.Cluster)
 			if err != nil {
 				return params.ErrorResult(err), nil, nil
 			}
@@ -108,7 +116,7 @@ func (h *handlers) describeK8SResource(ctx context.Context, _ *mcp.CallToolReque
 	}, nil, nil
 }
 
-func (h *handlers) describeObject(ctx context.Context, obj *unstructured.Unstructured, kind string, cluster params.Cluster) (string, error) {
+func (h *handlers) describeObject(ctx context.Context, obj *unstructured.Unstructured, kind string, isNamespaced bool, cluster params.Cluster) (string, error) {
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("Name: %s\n", obj.GetName()))
 	sb.WriteString(fmt.Sprintf("Namespace: %s\n", obj.GetNamespace()))
@@ -133,24 +141,31 @@ func (h *handlers) describeObject(ctx context.Context, obj *unstructured.Unstruc
 	// Show spec and status as YAML
 	spec, ok := obj.Object["spec"]
 	if ok {
-		specYAML, _ := yaml.Marshal(spec)
+		specYAML, err := yaml.Marshal(spec)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal spec to YAML: %w", err)
+		}
 		sb.WriteString("Spec:\n")
 		sb.WriteString(indent(string(specYAML), "  "))
 	}
 
 	status, ok := obj.Object["status"]
 	if ok {
-		statusYAML, _ := yaml.Marshal(status)
+		statusYAML, err := yaml.Marshal(status)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal status to YAML: %w", err)
+		}
 		sb.WriteString("Status:\n")
 		sb.WriteString(indent(string(statusYAML), "  "))
 	}
 
 	// Fetch events
 	eventsResult, _, err := h.listK8SEvents(ctx, nil, &listK8SEventsArgs{
-		Cluster:      cluster,
-		Name:         obj.GetName(),
-		Namespace:    obj.GetNamespace(),
-		ResourceType: kind,
+		Cluster:       cluster,
+		Name:          obj.GetName(),
+		Namespace:     obj.GetNamespace(),
+		ResourceType:  kind,
+		AllNamespaces: !isNamespaced,
 	})
 
 	if err == nil && !eventsResult.IsError && len(eventsResult.Content) > 0 {

--- a/pkg/tools/k8s/describe_test.go
+++ b/pkg/tools/k8s/describe_test.go
@@ -1,0 +1,141 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestDescribeK8SResource(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a fake unstructured pod
+	pod := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      "my-pod",
+				"namespace": "default",
+				"labels": map[string]interface{}{
+					"app": "myapp",
+				},
+			},
+			"spec": map[string]interface{}{
+				"containers": []interface{}{
+					map[string]interface{}{
+						"name":  "my-container",
+						"image": "nginx",
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, pod)
+
+	// Create fake clientset for events
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-event",
+			Namespace: "default",
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Kind:      "Pod",
+			Name:      "my-pod",
+			Namespace: "default",
+			APIVersion: "v1",
+		},
+		Message: "Test event message",
+		Reason:  "TestReason",
+		Type:    "Normal",
+		LastTimestamp: metav1.Time{Time: metav1.Now().Time},
+	}
+	fakeClientset := fake.NewSimpleClientset(event)
+
+	// Mock discovery for ResolveGVR
+	fakeDiscovery := fakeClientset.Discovery().(*fakediscovery.FakeDiscovery)
+	fakeDiscovery.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", Namespaced: true, Kind: "Pod"},
+			},
+		},
+	}
+
+	mockProvider := &mockClientProvider{
+		dynamicClient:    fakeDynamicClient,
+		kubernetesClient: fakeClientset,
+		discoveryClient:  fakeDiscovery,
+	}
+
+	h := &handlers{
+		c:        &config.Config{},
+		provider: mockProvider,
+	}
+
+	args := &describeK8SResourceArgs{
+		ResourceType: "pod",
+		Name:         "my-pod",
+		Namespace:    "default",
+	}
+	args.ProjectID = "p"
+	args.Location = "l"
+	args.ClusterName = "c"
+
+	result, _, err := h.describeK8SResource(ctx, &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatalf("describeK8SResource failed: %v", err)
+	}
+
+	if result.IsError {
+		t.Fatalf("describeK8SResource returned error result: %v", result.Content[0])
+	}
+
+	textContent, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("result.Content[0] is not TextContent")
+	}
+
+	if !strings.Contains(textContent.Text, "Name: my-pod") {
+		t.Errorf("output does not contain 'Name: my-pod'")
+	}
+	if !strings.Contains(textContent.Text, "Kind: Pod") {
+		t.Errorf("output does not contain 'Kind: Pod'")
+	}
+	if !strings.Contains(textContent.Text, "Spec:") {
+		t.Errorf("output does not contain 'Spec:'")
+	}
+	if !strings.Contains(textContent.Text, "Events:") {
+		t.Errorf("output does not contain 'Events:'")
+	}
+	if !strings.Contains(textContent.Text, "Test event message") {
+		t.Errorf("output does not contain 'Test event message'")
+	}
+}

--- a/pkg/tools/k8s/describe_test.go
+++ b/pkg/tools/k8s/describe_test.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
@@ -139,3 +140,61 @@ func TestDescribeK8SResource(t *testing.T) {
 		t.Errorf("output does not contain 'Test event message'")
 	}
 }
+
+func TestDescribeK8SResource_NoResources(t *testing.T) {
+	ctx := context.Background()
+
+	scheme := runtime.NewScheme()
+	gvrToKind := map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "pods"}: "PodList",
+	}
+	fakeDynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToKind)
+
+	fakeClientset := fake.NewSimpleClientset()
+	fakeDiscovery := fakeClientset.Discovery().(*fakediscovery.FakeDiscovery)
+	fakeDiscovery.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", Namespaced: true, Kind: "Pod"},
+			},
+		},
+	}
+
+	mockProvider := &mockClientProvider{
+		dynamicClient:    fakeDynamicClient,
+		kubernetesClient: fakeClientset,
+		discoveryClient:  fakeDiscovery,
+	}
+
+	h := &handlers{
+		c:        &config.Config{},
+		provider: mockProvider,
+	}
+
+	args := &describeK8SResourceArgs{
+		ResourceType: "pod",
+	}
+	args.ProjectID = "p"
+	args.Location = "l"
+	args.ClusterName = "c"
+
+	result, _, err := h.describeK8SResource(ctx, &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatalf("describeK8SResource failed: %v", err)
+	}
+
+	if result.IsError {
+		t.Fatalf("describeK8SResource returned error result: %v", result.Content[0])
+	}
+
+	textContent, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("result.Content[0] is not TextContent")
+	}
+
+	if !strings.Contains(textContent.Text, "No resources found.") {
+		t.Errorf("output %q does not contain %q", textContent.Text, "No resources found.")
+	}
+}
+

--- a/pkg/tools/k8s/describe_test.go
+++ b/pkg/tools/k8s/describe_test.go
@@ -66,14 +66,14 @@ func TestDescribeK8SResource(t *testing.T) {
 			Namespace: "default",
 		},
 		InvolvedObject: corev1.ObjectReference{
-			Kind:      "Pod",
-			Name:      "my-pod",
-			Namespace: "default",
+			Kind:       "Pod",
+			Name:       "my-pod",
+			Namespace:  "default",
 			APIVersion: "v1",
 		},
-		Message: "Test event message",
-		Reason:  "TestReason",
-		Type:    "Normal",
+		Message:       "Test event message",
+		Reason:        "TestReason",
+		Type:          "Normal",
 		LastTimestamp: metav1.Time{Time: metav1.Now().Time},
 	}
 	fakeClientset := fake.NewSimpleClientset(event)

--- a/pkg/tools/k8s/describe_test.go
+++ b/pkg/tools/k8s/describe_test.go
@@ -197,4 +197,3 @@ func TestDescribeK8SResource_NoResources(t *testing.T) {
 		t.Errorf("output %q does not contain %q", textContent.Text, "No resources found.")
 	}
 }
-

--- a/pkg/tools/k8s/tools.go
+++ b/pkg/tools/k8s/tools.go
@@ -84,5 +84,13 @@ func Install(_ context.Context, s *mcp.Server, c *config.Config) error {
 		Description: "Deletes a Kubernetes resource from a cluster. This is similar to running `kubectl delete`.",
 	}, h.deleteK8SResource)
 
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "describe_k8s_resource",
+		Description: "Shows the details of a specific Kubernetes resource. This is similar to running `kubectl describe`.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+	}, h.describeK8SResource)
+
 	return nil
 }


### PR DESCRIPTION
# Pull Request

## Why This Change

The OSS repository was missing the `describe_k8s_resource` tool which is available in the hosted service. This PR adds it to match functionality and schemas.

## What Changed

- Added `pkg/tools/k8s/describe.go` with `describe_k8s_resource` implementation.
- Updated `pkg/tools/k8s/tools.go` to register the new tool.
- Added `pkg/tools/k8s/describe_test.go` with unit tests.

**Files:**

- `pkg/tools/k8s/describe.go`
- `pkg/tools/k8s/tools.go`
- `pkg/tools/k8s/describe_test.go`

**Added/Changed/Fixed:**

- Added `describe_k8s_resource` tool.
- Added unit tests for `describe_k8s_resource`.

## Why This Matters

This change ensures parity between the OSS repository and the hosted service for the `describe_k8s_resource` tool, allowing users of the OSS repo to get detailed descriptions of Kubernetes resources.

## Context

This is part of the effort to match all MCP tools from the hosted service in this OSS repo.

## Testing

```bash
go build -v ./...
go test -v ./pkg/tools/k8s/...
```
All passed. I relied on focused checks for Go files as per guidelines.

---
