### PR TITLE
docs: fix tool name reference in instruction.md

### DIFF
--- a/pkg/agents/manifestgen/instruction.md
+++ b/pkg/agents/manifestgen/instruction.md
@@ -392,7 +392,7 @@ model-as-a-service solutions.
     `giq_generate_manifest`. You MUST first call `fetch_profiles`
     to identify a valid configuration. From the chosen `Profile`, you MUST
     extract and provide the following parameters to
-    `generate_optimized_manifest`:
+    `giq_generate_manifest`:
     *   **MANDATORY**: `model` (e.g., `google/gemma-4-31B-it`)
     *   **MANDATORY**: `model_server` (e.g., `vllm`)
     *   **MANDATORY**: `accelerator` (e.g., `nvidia-l4`)


### PR DESCRIPTION
# Pull Request

## Why This Change

Corrects a tool name reference in the manifest generation agent's instructions. The instructions previously directed the agent to use `generate_optimized_manifest`, which does not exist, whereas the actual registered MCP tool name is `giq_generate_manifest`. This mismatch led to tool calling errors and agent hallucination.

## What Changed

**Files:**

- `pkg/agents/manifestgen/instruction.md`

**Added/Changed/Fixed:**

- Fixed the tool name from `generate_optimized_manifest` to `giq_generate_manifest`.

## Why This Matters

Ensures the agent can successfully generate manifests by calling the correct tool registered in the MCP server.

## Context

Part of GKE Inference Quickstart manifest optimization.
ref #250

