### PR TITLE
fix: map target_ntpot_milliseconds in giq generate manifest tool

### DIFF
--- a/pkg/tools/giq/giq.go
+++ b/pkg/tools/giq/giq.go
@@ -73,6 +73,9 @@ func GenerateInferenceManifest(ctx context.Context, args *GenerateInferenceManif
 		if err != nil {
 			return "", fmt.Errorf("invalid target_ntpot_milliseconds: %w", err)
 		}
+		if ntpot <= 0 {
+			return "", fmt.Errorf("target_ntpot_milliseconds must be greater than zero, got %d", ntpot)
+		}
 		val := int32(ntpot)
 		req.PerformanceRequirements = &gkerecommenderpb.PerformanceRequirements{
 			TargetNtpotMilliseconds: &val,

--- a/pkg/tools/giq/giq.go
+++ b/pkg/tools/giq/giq.go
@@ -18,6 +18,7 @@ package giq
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	gkerecommender "cloud.google.com/go/gkerecommender/apiv1"
@@ -31,6 +32,17 @@ type GenerateInferenceManifestArgs struct {
 	ModelServer             string `json:"model_server" jsonschema:"The model server to use. Get the list of valid model servers from 'gcloud container ai profiles list --format='table(modelServerInfo.model,modelServerInfo.modelServer,modelServerInfo.modelServerVersion,acceleratorType)' if the user doesn't provide it. You can filter that gcloud command on '--model={model}' if the user provides the model."`
 	Accelerator             string `json:"accelerator" jsonschema:"The accelerator to use. Get the list of valid accelerators from 'gcloud container ai profiles list --format='table(modelServerInfo.model,modelServerInfo.modelServer,modelServerInfo.modelServerVersion,acceleratorType)' if the user doesn't provide it. You can filter that gcloud command on '--model={model}' and '--model-server={model-server}' if the user provides those values."`
 	TargetNTPOTMilliseconds string `json:"target_ntpot_milliseconds,omitempty" jsonschema:"The maximum normalized time per output token (NTPOT) in milliseconds.NTPOT is measured as the request_latency / output_tokens."`
+}
+
+var generateOptimizedManifestFunc = func(ctx context.Context, req *gkerecommenderpb.GenerateOptimizedManifestRequest) (*gkerecommenderpb.GenerateOptimizedManifestResponse, error) {
+	client, err := gkerecommender.NewGkeInferenceQuickstartClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gkerecommender client: %w", err)
+	}
+	defer func() {
+		_ = client.Close()
+	}()
+	return client.GenerateOptimizedManifest(ctx, req)
 }
 
 // GenerateInferenceManifest core logic for GKE Inference Quickstart manifest generation.
@@ -48,14 +60,6 @@ func GenerateInferenceManifest(ctx context.Context, args *GenerateInferenceManif
 		return "", fmt.Errorf("accelerator argument cannot be empty")
 	}
 
-	client, err := gkerecommender.NewGkeInferenceQuickstartClient(ctx)
-	if err != nil {
-		return "", fmt.Errorf("failed to create gkerecommender client: %w", err)
-	}
-	defer func() {
-		_ = client.Close()
-	}()
-
 	req := &gkerecommenderpb.GenerateOptimizedManifestRequest{
 		ModelServerInfo: &gkerecommenderpb.ModelServerInfo{
 			Model:       args.Model,
@@ -64,9 +68,20 @@ func GenerateInferenceManifest(ctx context.Context, args *GenerateInferenceManif
 		AcceleratorType: args.Accelerator,
 	}
 
-	resp, err := client.GenerateOptimizedManifest(ctx, req)
+	if args.TargetNTPOTMilliseconds != "" {
+		ntpot, err := strconv.ParseInt(args.TargetNTPOTMilliseconds, 10, 32)
+		if err != nil {
+			return "", fmt.Errorf("invalid target_ntpot_milliseconds: %w", err)
+		}
+		val := int32(ntpot)
+		req.PerformanceRequirements = &gkerecommenderpb.PerformanceRequirements{
+			TargetNtpotMilliseconds: &val,
+		}
+	}
+
+	resp, err := generateOptimizedManifestFunc(ctx, req)
 	if err != nil {
-		return "", fmt.Errorf("failed to generate optimized manifest via SDK: %w", err)
+		return "", fmt.Errorf("failed to generate optimized manifest: %w", err)
 	}
 
 	var manifests []string

--- a/pkg/tools/giq/giq_test.go
+++ b/pkg/tools/giq/giq_test.go
@@ -302,15 +302,27 @@ func TestGenerateInferenceManifest_Mock_Success(t *testing.T) {
 }
 
 func TestGenerateInferenceManifest_Mock_InvalidNTPOT(t *testing.T) {
-	args := &GenerateInferenceManifestArgs{
-		Model:                   "test-model",
-		ModelServer:             "test-server",
-		Accelerator:             "nvidia-l4",
-		TargetNTPOTMilliseconds: "not-a-number",
+	tests := []struct {
+		name  string
+		ntpot string
+	}{
+		{"not a number", "not-a-number"},
+		{"zero", "0"},
+		{"negative", "-100"},
 	}
 
-	_, err := GenerateInferenceManifest(context.Background(), args)
-	if err == nil {
-		t.Error("Expected error for invalid target_ntpot_milliseconds, got nil")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			args := &GenerateInferenceManifestArgs{
+				Model:                   "test-model",
+				ModelServer:             "test-server",
+				Accelerator:             "nvidia-l4",
+				TargetNTPOTMilliseconds: tc.ntpot,
+			}
+			_, err := GenerateInferenceManifest(context.Background(), args)
+			if err == nil {
+				t.Errorf("Expected error for target_ntpot_milliseconds=%q, got nil", tc.ntpot)
+			}
+		})
 	}
 }

--- a/pkg/tools/giq/giq_test.go
+++ b/pkg/tools/giq/giq_test.go
@@ -252,3 +252,65 @@ func TestFetchModelServerVersions_Validation(t *testing.T) {
 		t.Error("Expected error for empty modelServer, got nil")
 	}
 }
+
+func TestGenerateInferenceManifest_Mock_Success(t *testing.T) {
+	originalFunc := generateOptimizedManifestFunc
+	defer func() { generateOptimizedManifestFunc = originalFunc }()
+
+	generateOptimizedManifestFunc = func(_ context.Context, req *gkerecommenderpb.GenerateOptimizedManifestRequest) (*gkerecommenderpb.GenerateOptimizedManifestResponse, error) {
+		if req.ModelServerInfo.Model != "test-model" {
+			t.Errorf("Expected model 'test-model', got %q", req.ModelServerInfo.Model)
+		}
+		if req.ModelServerInfo.ModelServer != "test-server" {
+			t.Errorf("Expected modelServer 'test-server', got %q", req.ModelServerInfo.ModelServer)
+		}
+		if req.AcceleratorType != "nvidia-l4" {
+			t.Errorf("Expected acceleratorType 'nvidia-l4', got %q", req.AcceleratorType)
+		}
+		if req.PerformanceRequirements == nil {
+			t.Error("Expected PerformanceRequirements to be set, got nil")
+		} else if req.PerformanceRequirements.TargetNtpotMilliseconds == nil {
+			t.Error("Expected TargetNtpotMilliseconds to be set, got nil")
+		} else if *req.PerformanceRequirements.TargetNtpotMilliseconds != 500 {
+			t.Errorf("Expected TargetNtpotMilliseconds to be 500, got %d", *req.PerformanceRequirements.TargetNtpotMilliseconds)
+		}
+
+		return &gkerecommenderpb.GenerateOptimizedManifestResponse{
+			KubernetesManifests: []*gkerecommenderpb.KubernetesManifest{
+				{
+					Content: "manifest-content",
+				},
+			},
+		}, nil
+	}
+
+	args := &GenerateInferenceManifestArgs{
+		Model:                   "test-model",
+		ModelServer:             "test-server",
+		Accelerator:             "nvidia-l4",
+		TargetNTPOTMilliseconds: "500",
+	}
+
+	res, err := GenerateInferenceManifest(context.Background(), args)
+	if err != nil {
+		t.Fatalf("GenerateInferenceManifest returned error: %v", err)
+	}
+
+	if res != "manifest-content" {
+		t.Errorf("GenerateInferenceManifest = %q, want 'manifest-content'", res)
+	}
+}
+
+func TestGenerateInferenceManifest_Mock_InvalidNTPOT(t *testing.T) {
+	args := &GenerateInferenceManifestArgs{
+		Model:                   "test-model",
+		ModelServer:             "test-server",
+		Accelerator:             "nvidia-l4",
+		TargetNTPOTMilliseconds: "not-a-number",
+	}
+
+	_, err := GenerateInferenceManifest(context.Background(), args)
+	if err == nil {
+		t.Error("Expected error for invalid target_ntpot_milliseconds, got nil")
+	}
+}


### PR DESCRIPTION
# Pull Request

## Why This Change

Fixes a bug in the GIQ (GKE Inference Quickstart) manifest generation tool where the existing `target_ntpot_milliseconds` parameter in `GenerateInferenceManifestArgs` was parsed but completely ignored and never forwarded to the underlying `GenerateOptimizedManifestRequest` SDK call.

## What Changed

**Files:**

- `pkg/tools/giq/giq.go`
- `pkg/tools/giq/giq_test.go`

**Added/Changed/Fixed:**

- Mapped `TargetNTPOTMilliseconds` to `PerformanceRequirements.TargetNtpotMilliseconds` in the GkeRecommender request struct.
- Extracted `generateOptimizedManifestFunc` as a package-level variable to enable unit test mocking.
- Added unit tests `TestGenerateInferenceManifest_Mock_Success` and `TestGenerateInferenceManifest_Mock_InvalidNTPOT` to verify correct parameter mapping and error handling.

## Why This Matters

Ensures that latency requirements configured via `target_ntpot_milliseconds` are properly respected by the GKE Inference Quickstart manifest generator when deploying optimized workloads.

## Context

Part of GKE Inference Quickstart manifest optimization.
ref #250

## Testing

```bash
go test -v ./pkg/tools/giq/...  # Pass
```
