### PR TITLE
docs(manifestgen): map giq_fetch_model_servers to gcloud command

### DIFF
--- a/pkg/agents/manifestgen/instruction.md
+++ b/pkg/agents/manifestgen/instruction.md
@@ -365,7 +365,7 @@ use the corresponding MCP tool to accomplish the task.
 
 -   giq_fetch_models: gcloud container ai profiles models list
 -   giq_fetch_profiles: gcloud container ai profiles list
--   giq_fetch_model_servers: Find available model servers for a given model.
+-   giq_fetch_model_servers: gcloud container ai profiles model-servers list --model=MODEL
 -   giq_fetch_model_server_versions: Find available versions for a given model and model server.
 -   giq_generate_manifest: gcloud container ai profiles manifests create
 


### PR DESCRIPTION
# Description

## 🎯 Why This Change?
Aligning the documentation for the `giq_fetch_model_servers` MCP tool with its underlying Google Cloud CLI equivalent. This helps both developer understanding and model prompt alignment by explicitly mapping the MCP tool to its corresponding `gcloud container ai` command.

## 📝 What Changed?
Updated `pkg/agents/manifestgen/instruction.md` to map `giq_fetch_model_servers` to its equivalent `gcloud` command instead of a generic description.

-   **Before:** `-   giq_fetch_model_servers: Find available model servers for a given model.`
-   **After:** `-   giq_fetch_model_servers: gcloud container ai profiles model-servers list`

## ✅ Why This Matters
1. **Model Accuracy:** The manifest generation agent relies on the instructions in `instruction.md` to map user intent to correct tools. Having clear CLI mappings improves the agent's contextual understanding.
2. **Developer Transparency:** Explicitly documenting CLI equivalents allows developers to easily run the same commands manually for testing/debugging.
3. **Consistency:** Matches the existing pattern of other tools like `fetch_models` (`gcloud container ai profiles models list`) and `giq_generate_manifest` (`gcloud container ai profiles manifests create`).

ref #250
