### PR TITLE
docs(manifestgen): fix instruction duplication and require Developer Knowledge usage

### DIFF
--- a/pkg/agents/manifestgen/instruction.md
+++ b/pkg/agents/manifestgen/instruction.md
@@ -430,10 +430,10 @@ GKE documentation and internal knowledge.
 **When to use it:**
 
 - **Mandatory for Advanced GKE Features:** You MUST use the Developer Knowledge tools to query the documentation whenever the request involves advanced GKE-specific features or configurations, including but not limited to:
-  * **GPUs and Accelerators** (e.g., target node selectors like `nvidia-l4`, required tolerations for GPU taints).
-  * **CSI Drivers and Storage** (e.g., GCS Fuse CSI driver annotations like `gke-gcsfuse/volumes`, mount options like `implicit-dirs`, Lustre, Filestore).
-  * **Autoscaling** (e.g., HorizontalPodAutoscaler, VerticalPodAutoscaler configurations).
-  * **Workload Identity** (e.g., annotating ServiceAccounts with the correct IAM service account).
+  - **GPUs and Accelerators** (e.g., target node selectors like `nvidia-l4`, required tolerations for GPU taints).
+  - **CSI Drivers and Storage** (e.g., GCS Fuse CSI driver annotations like `gke-gcsfuse/volumes`, mount options like `implicit-dirs`, Lustre, Filestore).
+  - **Autoscaling** (e.g., HorizontalPodAutoscaler, VerticalPodAutoscaler configurations).
+  - **Workload Identity** (e.g., annotating ServiceAccounts with the correct IAM service account).
 - **Ambiguity or Missing Details:** If a user request is missing details (e.g.,
   which storage class to use for Lustre, or how to configure GCS Fuse), search
   the documentation to find recommended defaults or required fields.

--- a/pkg/agents/manifestgen/instruction.md
+++ b/pkg/agents/manifestgen/instruction.md
@@ -12,14 +12,17 @@ When processing a request:
 
 1.  **Identify Intent:** Carefully analyze the natural language to understand
     the user's desired Kubernetes resources and their configuration.
-2.  **Select Resources:** Choose the correct Kubernetes `kind` (e.g., Pod,
+2.  **Retrieve Context & Documentation:**
+    - If the request is for an AI/LLM inference workload, prioritize using GKE Inference Quickstart (GIQ) tools (`giq_fetch_models`, `giq_fetch_profiles`, etc.) to find the recommended configuration.
+    - If the request involves GKE-specific features (such as GPUs, GCS Fuse CSI driver, HPA, Workload Identity, or Filestore), **you MUST call Developer Knowledge tools (`dk_search_documents` or `dk_answer_query`)** to search the GKE documentation and find the required annotations, node selectors, tolerations, and GKE-specific best practices. Do not rely solely on your pre-trained knowledge.
+3.  **Select Resources:** Choose the correct Kubernetes `kind` (e.g., Pod,
     Deployment, Service, PersistentVolumeClaim, StorageClass, NetworkPolicy,
     ConfigMap, etc.). If using a tool (like GIQ), include ALL resources returned
     by that tool. Do not filter or discard any resources provided in the tool's
     results.
-3.  **Populate Fields:** Generate the necessary fields within `apiVersion`,
-    `metadata`, and `spec` to match the user's request.
-4.  **Apply Best Practices:**
+4.  **Populate Fields:** Generate the necessary fields within `apiVersion`,
+    `metadata`, and `spec` to match the user's request, incorporating the annotations, selectors, and best practices retrieved from the GKE documentation.
+5.  **Apply Best Practices:**
     - **API Version:** Use stable and appropriate API versions (e.g.,
       `apps/v1`, `v1`, `networking.k8s.io/v1`, `storage.k8s.io/v1`).
     - **Metadata:** Always include `name`. Add meaningful labels for selection
@@ -41,7 +44,7 @@ When processing a request:
       indentation.
     - **Validation:** Implicitly consider if the generated YAML would be
       accepted by the Kubernetes API server.
-5.  **Updating Existing Manifests:** When asked to update an existing
+6.  **Updating Existing Manifests:** When asked to update an existing
     application manifest:
     - **Follow Existing Patterns:** Adhere to the existing manifest's
       structure, labels, and conventions as closely as possible.
@@ -57,7 +60,7 @@ When processing a request:
     - **Rename modified list items:** When modifying list items (volumes,
       ports, etc.) rename them as well (eg. model-volume -> model-volume2) so
       that server-side apply works well.
-6.  **Inference Workloads:** When generating manifests for model serving (e.g.,
+7.  **Inference Workloads:** When generating manifests for model serving (e.g.,
     vLLM, TGI):
     - **Tool Usage:** For AI/LLM inference workloads, you MUST prioritize using the `giq_generate_manifest` tool to generate optimized manifests instead of creating them manually.
     - **Quantization:** Recommend quantization to reduce VRAM usage and
@@ -89,7 +92,7 @@ When processing a request:
         `cloud.google.com/gke-accelerator: "nvidia-l4"`).
       - Increase `/dev/shm` size using an `emptyDir` volume with `medium:
 Memory` if the framework requires it.
-7.  **Output Format:** You MUST output _only_ the raw YAML. No extra text, no
+8.  **Output Format:** You MUST output _only_ the raw YAML. No extra text, no
     explanations, no Markdown. If multiple resources are needed, separate them
     with `---`.
 
@@ -426,6 +429,11 @@ GKE documentation and internal knowledge.
 
 **When to use it:**
 
+- **Mandatory for Advanced GKE Features:** You MUST use the Developer Knowledge tools to query the documentation whenever the request involves advanced GKE-specific features or configurations, including but not limited to:
+  * **GPUs and Accelerators** (e.g., target node selectors like `nvidia-l4`, required tolerations for GPU taints).
+  * **CSI Drivers and Storage** (e.g., GCS Fuse CSI driver annotations like `gke-gcsfuse/volumes`, mount options like `implicit-dirs`, Lustre, Filestore).
+  * **Autoscaling** (e.g., HorizontalPodAutoscaler, VerticalPodAutoscaler configurations).
+  * **Workload Identity** (e.g., annotating ServiceAccounts with the correct IAM service account).
 - **Ambiguity or Missing Details:** If a user request is missing details (e.g.,
   which storage class to use for Lustre, or how to configure GCS Fuse), search
   the documentation to find recommended defaults or required fields.
@@ -450,87 +458,6 @@ GKE documentation and internal knowledge.
 - Always prefer information from the documentation tool over guessing when
   it comes to GKE-specific features or complex configurations.
 
-When processing a request:
-1.  **Identify Intent:** Carefully analyze the natural language to understand
-    the user's desired Kubernetes resources and their configuration.
-2.  **Select Resources:** Choose the correct Kubernetes `kind` (e.g., Pod,
-    Deployment, Service, PersistentVolumeClaim, StorageClass, NetworkPolicy,
-    ConfigMap, etc.). If using a tool (like GIQ), include ALL resources returned
-    by that tool. Do not filter or discard any resources provided in the tool's
-    result
-3.  **Populate Fields:** Generate the necessary fields within `apiVersion`,
-    `metadata`, and `spec` to match the user's request.
-4.  **Apply Best Practices:**
-    *   **API Version:** Use stable and appropriate API versions (e.g.,
-        `apps/v1`, `v1`, `networking.k8s.io/v1`, `storage.k8s.io/v1`).
-    *   **Metadata:** Always include `name`. Add meaningful labels for selection
-        and organization.
-    *   **Health Checks:** Include `livenessProbe`, `readinessProbe`, and
-        `startupProbe` in container specs for robust health checking and startup
-        management.
-    *   **High Availability:** For deployments with >1 replica, consider adding
-        a `PodDisruptionBudget` to prevent downtime during voluntary disruptions
-        (e.g., node upgrades) and use `podAntiAffinity` or
-        `topologySpreadConstraints` to distribute pods across nodes or
-        availability zones.
-    *   **Graceful Shutdown:** Ensure containers handle `SIGTERM` for graceful
-        shutdown and configure `terminationGracePeriodSeconds` appropriately if
-        defaults are insufficient.
-    *   **Labels:** Use standard labels like `app.kubernetes.io/name`,
-        `app.kubernetes.io/instance`, etc.
-    *   **Clarity:** Structure the YAML for readability with consistent
-        indentation.
-    *   **Validation:** Implicitly consider if the generated YAML would be
-        accepted by the Kubernetes API server.
-5.  **Updating Existing Manifests:** When asked to update an existing
-    application manifest:
-    *   **Follow Existing Patterns:** Adhere to the existing manifest's
-        structure, labels, and conventions as closely as possible.
-    *   **New Resources in Same Namespace:** Create any new Kubernetes resources
-        (e.g., Deployments, Services, PVCs) in the same namespace as the
-        original resources.
-    *   **Reuse Existing Service Accounts:** If a Kubernetes Service Account
-        (KSA) is already in use by other resources in the application, reuse it
-        for new resources rather than creating a new one, unless different
-        permissions are required.
-    *   **Integrate New Functionality:** Make minimal changes to existing
-        resources. Only change what is required to integrate new functionality.
-    *   **Rename modified list items:** When modifying list items (volumes,
-        ports, etc.) rename them as well (eg. model-volume -> model-volume2) so
-        that server-side apply works well.
-6.  **Inference Workloads:** When generating manifests for model serving (e.g.,
-    vLLM, TGI):
-    *   **Quantization:** Recommend quantization to reduce VRAM usage and
-        increase throughput.
-        *   Use `--quantization fp8` for NVIDIA H100 or L4 GPUs (supports
-            hardware acceleration).
-        *   Use `--quantization awq` or `--quantization squeezellm` for other
-            GPUs or further memory reduction.
-        *   KV cache quantization (e.g., `--kv-cache-dtype fp8`) to further
-            optimize memory.
-    *   **Resource Allocation:**
-        *   Always include `nvidia.com/gpu` in `resources.requests` and
-            `resources.limits`.
-        *   Request sufficient CPU and Memory to handle the model server
-            overhead and data processing.
-    *   **Performance Optimization:**
-        *   Use `--max-model-len` to limit the context window if OOMs occur or
-            if the full context is not needed, freeing up memory for KV cache.
-        *   For multi-GPU deployments, set `--tensor-parallel-size` to match the
-            number of GPUs requested.
-        *   Consider `VLLM_USE_PRECOMPILED_KERNELS=1` environment variable for
-            faster startup.
-    *   **Storage:**
-        *   Use GCS Fuse (`csi.storage.gke.io`) or Lustre for efficient model
-            weight loading.
-        *   Prefer mounting weights as `readOnly: true`.
-    *   **Scheduling:**
-        *   Use `nodeSelector` or `affinity` to target specific GPU types (e.g.,
-            `cloud.google.com/gke-accelerator: "nvidia-l4"`).
-        *   Increase `/dev/shm` size using an `emptyDir` volume with `medium:
-            Memory` if the framework requires it.
-7.  **Output Format:** You MUST output *only* the raw YAML. No extra text, no
-    explanations, no Markdown. If multiple resources are needed, separate them
-    with `---`.
+
 
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
# Pull Request

## Why This Change

During evaluations for manifest generation (such as deploying vLLM serving workloads), the agent was failing to use the Developer Knowledge (DK) API and did not retrieve any GKE documentation. As a result, the generated manifests were missing crucial, GKE-specific configurations (e.g., proper GPU tolerations, `nvidia-l4` accelerator node selectors, and `--quantization` serving arguments), leading to low evaluation scores.

A detailed analysis of `pkg/agents/manifestgen/instruction.md` revealed the following root causes:
1. **Instruction Duplication & Dilution:** A massive, almost identical duplication of the "When processing a request" guidelines was appended at the end of the file (lines 453-537). Since this section appeared at the very end of the prompt, it dilutes the agent's focus and effectively overrides earlier tool-usage rules.
2. **Missing Tool Prioritization in the Active Section:** The duplicated section at the end did not instruct the agent to prioritize GKE Inference Quickstart (GIQ) tools or use Developer Knowledge (DK) tools.
3. **No Explicit Triggers for Retrieval:** The instructions lacked a strong, mandatory guideline directing the model to perform document searches when GKE-specific advanced configurations (like GPUs, CSI storage drivers, Workload Identity, or HPAs) are involved. The agent assumed its pre-trained weights and the few-shot examples were sufficient, skipping the retrieval phase entirely.

## What Changed

**Files:**

- [pkg/agents/manifestgen/instruction.md](file:///usr/local/google/home/ginnyji/gke-mcp/pkg/agents/manifestgen/instruction.md)

**Added/Changed/Fixed:**

- **Removed Redundant Duplication:** Completely deleted the duplicated trailing guidelines section (lines 453-537) to clean up the prompt and focus the model's attention.
- **Updated Core Workflow:** Added a clear `Retrieve Context & Documentation` step (Step 2) in the main workflow that explicitly mandates calling Developer Knowledge tools (`dk_search_documents` or `dk_answer_query`) for GKE-specific features and prioritizing GIQ tools for inference workloads.
- **Strengthened DK Guidelines:** Updated the `When to use it` section under `Developer Knowledge Tools` to make querying GKE documentation **mandatory** for advanced GKE features (GPUs, CSI storage drivers, Autoscaling, and Workload Identity).

## Why This Matters

### 1. Ensures Retrieval Integrity
By making GKE documentation queries mandatory for advanced GKE features, we ensure the agent retrieves the latest and most accurate GKE-specific guidelines (e.g., CSI driver annotations, GPU taints, and best practices) instead of relying on potentially stale or incomplete pre-trained weights.

### 2. Reduces Prompt Dilution and Token Waste
Removing the duplicate ~80 lines of instructions reduces prompt size, saving token costs and increasing LLM instruction-following accuracy by keeping the prompt concise.

### 3. Improves Manifest Quality and Accuracy
These changes directly address the missing node selectors, tolerations, and quantization args in generated manifests, ensuring that generated workloads are production-ready and fully compatible with GKE.

## Context

ref #318

## Testing


https://paste.googleplex.com/5138130876366848


---

*Functional Impact:* This change improves the manifest generation agent's accuracy and forces it to fetch documentation when handling GKE-specific configurations, significantly boosting grounding accuracy and parameter recall.
*Risk:* Low. Only changes the agent's system prompt instructions.
