### PR TITLE
fix(dk): correct SearchDocuments HTTP method to GET to fix 404

### DIFF
--- a/pkg/clients/dk/dk_client.go
+++ b/pkg/clients/dk/dk_client.go
@@ -96,6 +96,52 @@ func (c *RealDeveloperKnowledgeClient) doPost(ctx context.Context, path string, 
 	return string(body), nil
 }
 
+// doGet executes a GET request to the Developer Knowledge API.
+func (c *RealDeveloperKnowledgeClient) doGet(ctx context.Context, path string, queryParams map[string]string) (string, error) {
+	reqURL, err := url.JoinPath(c.baseURL, path)
+	if err != nil {
+		return "", err
+	}
+	parsedURL, err := url.Parse(reqURL)
+	if err != nil {
+		return "", err
+	}
+	q := parsedURL.Query()
+	for k, v := range queryParams {
+		q.Set(k, v)
+	}
+	parsedURL.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsedURL.String(), nil)
+	if err != nil {
+		return "", err
+	}
+	if c.apiKey != "" {
+		req.Header.Set("X-Goog-Api-Key", c.apiKey)
+	}
+	if c.userAgent != "" {
+		req.Header.Set("User-Agent", c.userAgent)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+		return "", fmt.Errorf("API request failed with status %s: %s", resp.Status, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
 // GetDocuments fetches specific documents by their IDs.
 func (c *RealDeveloperKnowledgeClient) GetDocuments(ctx context.Context, documentIDs []string) (string, error) {
 	if len(documentIDs) == 0 {
@@ -108,14 +154,14 @@ func (c *RealDeveloperKnowledgeClient) GetDocuments(ctx context.Context, documen
 
 // AnswerQuery answers a query based on the knowledge base.
 func (c *RealDeveloperKnowledgeClient) AnswerQuery(ctx context.Context, query string) (string, error) {
-	return c.doPost(ctx, "/v1alpha/TopLevel:answerQuery", map[string]interface{}{
+	return c.doPost(ctx, "/v1/TopLevel:answerQuery", map[string]interface{}{
 		"query": query,
 	})
 }
 
 // SearchDocuments searches for documents related to a query.
 func (c *RealDeveloperKnowledgeClient) SearchDocuments(ctx context.Context, query string) (string, error) {
-	return c.doPost(ctx, "/v1/documents:searchDocumentChunks", map[string]interface{}{
+	return c.doGet(ctx, "/v1/documents:searchDocumentChunks", map[string]string{
 		"query": query,
 	})
 }

--- a/pkg/clients/dk/dk_client.go
+++ b/pkg/clients/dk/dk_client.go
@@ -98,14 +98,11 @@ func (c *RealDeveloperKnowledgeClient) doPost(ctx context.Context, path string, 
 
 // doGet executes a GET request to the Developer Knowledge API.
 func (c *RealDeveloperKnowledgeClient) doGet(ctx context.Context, path string, queryParams map[string]string) (string, error) {
-	reqURL, err := url.JoinPath(c.baseURL, path)
+	parsedURL, err := url.Parse(c.baseURL)
 	if err != nil {
 		return "", err
 	}
-	parsedURL, err := url.Parse(reqURL)
-	if err != nil {
-		return "", err
-	}
+	parsedURL = parsedURL.JoinPath(path)
 	q := parsedURL.Query()
 	for k, v := range queryParams {
 		q.Set(k, v)

--- a/pkg/clients/dk/dk_client_test.go
+++ b/pkg/clients/dk/dk_client_test.go
@@ -44,8 +44,8 @@ func TestRealDeveloperKnowledgeClient_SearchDocuments(t *testing.T) {
 	mockResponse := `{"results": [{"chunk": "details"}]}`
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			t.Errorf("Expected method POST, got %s", r.Method)
+		if r.Method != http.MethodGet {
+			t.Errorf("Expected method GET, got %s", r.Method)
 		}
 		if r.URL.Path != "/v1/documents:searchDocumentChunks" {
 			t.Errorf("Expected path /v1/documents:searchDocumentChunks, got %s", r.URL.Path)
@@ -53,21 +53,13 @@ func TestRealDeveloperKnowledgeClient_SearchDocuments(t *testing.T) {
 		if r.Header.Get("X-Goog-Api-Key") != "test-api-key" {
 			t.Errorf("Expected API Key header, got %s", r.Header.Get("X-Goog-Api-Key"))
 		}
-		if r.Header.Get("Content-Type") != "application/json" {
-			t.Errorf("Expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
-		}
 		if r.Header.Get("User-Agent") != "gke-mcp/test" {
 			t.Errorf("Expected User-Agent gke-mcp/test, got %s", r.Header.Get("User-Agent"))
 		}
 
-		var body map[string]interface{}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Errorf("Failed to decode request body: %v", err)
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-		if body["query"] != expectedQuery {
-			t.Errorf("Expected query %q, got %q", expectedQuery, body["query"])
+		query := r.URL.Query().Get("query")
+		if query != expectedQuery {
+			t.Errorf("Expected query %q, got %q", expectedQuery, query)
 		}
 
 		w.WriteHeader(http.StatusOK)
@@ -111,8 +103,8 @@ func TestRealDeveloperKnowledgeClient_AnswerQuery(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("Expected method POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/v1alpha/TopLevel:answerQuery" {
-			t.Errorf("Expected path /v1alpha/TopLevel:answerQuery, got %s", r.URL.Path)
+		if r.URL.Path != "/v1/TopLevel:answerQuery" {
+			t.Errorf("Expected path /v1/TopLevel:answerQuery, got %s", r.URL.Path)
 		}
 		if r.Header.Get("X-Goog-Api-Key") != "test-api-key" {
 			t.Errorf("Expected API Key header, got %s", r.Header.Get("X-Goog-Api-Key"))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -99,9 +99,12 @@ func New(version string, enableDeleteTools bool) *Config {
 
 	dkBaseURL := os.Getenv("DK_BASE_URL")
 	if dkBaseURL == "" {
-		dkBaseURL = "https://knowledge.googleapis.com"
+		dkBaseURL = "https://developerknowledge.googleapis.com"
 	}
 	dkAPIKey := os.Getenv("DK_API_KEY")
+	if dkAPIKey == "" {
+		dkAPIKey = os.Getenv("GEMINI_API_KEY")
+	}
 
 	return &Config{
 		userAgent:         "gke-mcp/" + version,


### PR DESCRIPTION
# Pull Request

## Why This Change

This PR fixes a critical integration issue with the Developer Knowledge API (`dk_search_documents` tool). 
The `SearchDocuments` client method was originally implemented as an HTTP `POST` request to `/v1/documents:searchDocumentChunks`.

Upon direct validation of the Google Developer Knowledge API gateway, it was discovered that the endpoint `/v1/documents:searchDocumentChunks` is strictly a `GET` endpoint, passing the search query as a URL query parameter. Making `POST` requests to this path resulted in a silent `404 Not Found` returned by the ESF API gateway.

By correcting this HTTP method and payload structure, we successfully enable robust Grounded RAG retrieval for GKE manifest generation.

## What Changed

**Files:**

- [dk_client.go](file:///usr/local/google/home/ginnyji/gke-mcp/pkg/clients/dk/dk_client.go): Added `doGet` HTTP helper method, and refactored `SearchDocuments` to perform a `GET` request on `/v1/documents:searchDocumentChunks` with query parameters.
- [dk_client_test.go](file:///usr/local/google/home/ginnyji/gke-mcp/pkg/clients/dk/dk_client_test.go): Rewrote the `SearchDocuments` unit test to assert a `GET` method request, the correct path, and verify parameters.
- [config.go](file:///usr/local/google/home/ginnyji/gke-mcp/pkg/config/config.go): Updated the default `dkBaseURL` to the official `https://developerknowledge.googleapis.com` domain, and enabled a fallback to `GEMINI_API_KEY` for local development. 

**Added/Changed/Fixed:**

- Fixed the `404 Not Found` error on `dk_search_documents` tool execution.
- Added a clean `doGet` request handler to `RealDeveloperKnowledgeClient`.

## Why This Matters

### 1. Accurate GKE Configurations
By enabling document search (RAG) during manifest generation, the LLM will always ground its output in the most up-to-date GKE documentation (e.g., GCS FUSE annotations, NodeSelectors, tolerations, and best practices).

### 2. Elimination of Hallucinations
The agent no longer relies on static knowledge for rapidly evolving GKE features, reducing errors in generated YAML files.

### 3. API Compliance & Robustness
Aligns our Go HTTP client implementation with the actual REST protocol expected by the official Google Developer Knowledge API gateway.

## Context

This integration is critical for manifest generation grounding.

ref #318

## Testing

Local e2e test with logs clearly show the dk api response https://paste.googleplex.com/5920937252880384