### PR TITLE
feat(skills): add gke-tpu-metrics-monitoring skill

### DIFF
--- a/skills/gke-tpu-metrics-monitoring/BUILD
+++ b/skills/gke-tpu-metrics-monitoring/BUILD
@@ -1,0 +1,8 @@
+load("//learning/gemini/agents/skill_rules:skills.bzl", "agent_skill")
+
+package(default_visibility = ["//learning/gemini/agents/skills:__subpackages__"])
+
+agent_skill(
+    name = "gke_tpu_metrics_monitoring",
+    srcs = ["SKILL.md"],
+)

--- a/skills/gke-tpu-metrics-monitoring/EVAL.yaml
+++ b/skills/gke-tpu-metrics-monitoring/EVAL.yaml
@@ -1,0 +1,26 @@
+---
+suite_name: "gke_tpu_metrics_monitoring"
+timeout_seconds: 300
+cases:
+  - name: "tpu_metrics_no_context"
+    prompt: >
+      My TPU workload is running slow. How can I check if the TPUs are being
+      fully utilized?
+    expectations: |
+      The agent must:
+      - Ask for the missing context (Project ID, Cluster Name, Region/Zone)
+      - Identify that TPU duty cycle or TensorCore utilization are the key metrics to check.
+      - Indicate that it needs the context to help the user query or analyze these metrics for their specific cluster.
+
+  - name: "tpu_metrics_with_context"
+    prompt: >
+      My TPU workload is running slow in project 'my-project',
+      cluster 'my-cluster', zone 'us-central1-a'. I want to check the TPU
+      duty cycle and memory. What metrics should I look at and what do they
+      mean?
+    expectations: |
+      The agent must:
+      - Use the `gke-tpu-metrics-monitoring` skill
+      - List the runtime metrics: `kubernetes.io/container/accelerator/duty_cycle`, `kubernetes.io/container/accelerator/memory_used`, and `kubernetes.io/container/accelerator/memory_total`.
+      - Explain that `duty_cycle` is the percentage of time TensorCores were actively processing, and `memory_used`/`memory_total` are for memory allocation.
+      - Mention the requirement of `containerPort: 8431` in the pod spec.

--- a/skills/gke-tpu-metrics-monitoring/README.md
+++ b/skills/gke-tpu-metrics-monitoring/README.md
@@ -1,0 +1,18 @@
+# GKE TPU Metrics Monitoring Skill
+
+This skill provides diagnostics and queries to monitor GKE TPU workloads, nodes, and node pools using GKE system metrics.
+
+## When to Use
+
+Use this skill when:
+
+- You want to monitor the utilization (duty cycle, memory) of GKE TPUs.
+- A GKE TPU workload has failed or restarted, and you want to determine if it was due to node preemption, host error, or node pool issues.
+- You want to calculate MTTR (Mean Time to Recovery) or MTBI (Mean Time Between Interruptions) for TPU node pools.
+- You need to check if TPU nodes are Ready or experiencing Disk/Memory pressure.
+
+## Prerequisites
+
+- GKE version requirements vary by metric (most require 1.27.4+, some 1.28.1+, node status requires 1.32.1+).
+- TPU workloads must be configured to export metrics (e.g., `containerPort: 8431` and JAX 0.4.14+).
+- GKE System Metrics must be enabled in the cluster.

--- a/skills/gke-tpu-metrics-monitoring/SKILL.md
+++ b/skills/gke-tpu-metrics-monitoring/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: gke-tpu-metrics-monitoring
+description: Monitor and troubleshoot GKE TPU workloads using GKE system metrics and PromQL.
+---
+
+# GKE TPU Metrics Monitoring Guide
+
+This skill enables the agent to monitor GKE TPU workloads, nodes, and node pools using GKE system metrics. It helps diagnose if workload interruptions or performance issues are caused by underlying infrastructure.
+
+## Step 0: Mandatory Context
+
+To run these diagnostics, the following context is required:
+
+- `<project_id>`: The GCP Project ID.
+- `<cluster_name>`: The GKE Cluster Name.
+- `<location>`: The GKE Cluster Location (region or zone).
+- `<node_name>`: (Optional) The name of the specific GKE node.
+- `<node_pool_name>`: (Optional) The name of the GKE node pool.
+
+---
+
+## Diagnostic Steps
+
+### Step 1: Verify TPU Runtime Metrics Configuration [Low Risk] [Auto]
+
+Before analyzing runtime metrics, verify that the workload is configured to export them.
+
+- **Action**: Verify that the Pod specification for the TPU workload includes:
+  - `containerPort: 8431`
+  - JAX version `0.4.14` or later (if using JAX).
+  - GKE version is `1.27.4-gke.900` or later.
+  - GKE System Metrics are enabled on the cluster.
+
+### Step 2: Monitor TPU Runtime Metrics [Low Risk] [Auto]
+
+If configured correctly, the following metrics are available in Cloud Monitoring (monitored resources `k8s_node` and `k8s_container`):
+
+- **Container Metrics**:
+  - `kubernetes.io/container/accelerator/duty_cycle`: Percentage of time over the past sampling period (60 seconds) during which the TensorCores were actively processing on a TPU chip.
+  - `kubernetes.io/container/accelerator/memory_used`: Amount of accelerator memory allocated in bytes.
+  - `kubernetes.io/container/accelerator/memory_total`: Total accelerator memory in bytes.
+- **Node Metrics**:
+  - `kubernetes.io/node/accelerator/duty_cycle`
+  - `kubernetes.io/node/accelerator/memory_used`
+  - `kubernetes.io/node/accelerator/memory_total`
+
+### Step 3: Check Node Status Condition [Low Risk] [Auto]
+
+Query the status condition of GKE nodes (GKE version `1.32.1-gke.1357001` or later).
+
+- **PromQL Query (Check if a specific node is Ready)**:
+  ```promql
+  kubernetes_io:node_status_condition{monitored_resource="k8s_node", cluster_name="<cluster_name>", node_name="<node_name>", condition="Ready", status="True"}
+  ```
+- **PromQL Query (List nodes with non-Ready conditions that are True)**:
+  ```promql
+  kubernetes_io:node_status_condition{monitored_resource="k8s_node", cluster_name="<cluster_name>", condition!="Ready", status="True"}
+  ```
+- **PromQL Query (List nodes that are NOT Ready)**:
+  ```promql
+  kubernetes_io:node_status_condition{monitored_resource="k8s_node", cluster_name="<cluster_name>", condition="Ready", status="False"}
+  ```
+- **PromQL Query (Fleet-wide node status)**:
+  ```promql
+  avg by (condition,status)(avg_over_time(kubernetes_io:node_status_condition{monitored_resource="k8s_node"}[5m]))
+  ```
+
+### Step 4: Check Node Pool Status [Low Risk] [Auto]
+
+Query the status of multi-host TPU node pools.
+
+- **PromQL Query (Verify if a specific node pool is Running)**:
+  ```promql
+  kubernetes_io:node_pool_status{monitored_resource="k8s_node_pool", cluster_name="<cluster_name>", node_pool_name="<node_pool_name>", status="Running"}
+  ```
+- **PromQL Query (Monitor node pools grouped by status)**:
+  ```promql
+  count by (status)(count_over_time(kubernetes_io:node_pool_status{monitored_resource="k8s_node_pool"}[5m]))
+  ```
+  _Possible statuses_: `Provisioning`, `Running`, `Error`, `Reconciling`, `Stopping`.
+
+### Step 5: Check Node Pool Availability [Low Risk] [Auto]
+
+Query if all nodes in a multi-host TPU node pool are available.
+
+- **PromQL Query (Check availability over time)**:
+  ```promql
+  avg by (node_pool_name)(avg_over_time(kubernetes_io:node_pool_multi_host_available{monitored_resource="k8s_node_pool", cluster_name="<cluster_name>"}[5m]))
+  ```
+  _Value_: `1` (True, all nodes available) or `0` (False, some nodes unavailable).
+
+### Step 6: Analyze Node Interruptions [Low Risk] [Auto]
+
+Query the count of interruptions for GKE nodes.
+
+- **PromQL Query (Breakdown of interruptions and causes)**:
+  ```promql
+  sum by (interruption_type,interruption_reason)(sum_over_time(kubernetes_io:node_interruption_count{monitored_resource="k8s_node"}[5m]))
+  ```
+  _Interruption Types_: `TerminationEvent`, `MaintenanceEvent`, `PreemptionEvent`.
+  _Interruption Reasons_: `HostError`, `Eviction`, `AutoRepair`.
+- **PromQL Query (Filter for Host Maintenance events)**:
+  ```promql
+  sum by (interruption_type,interruption_reason)(sum_over_time(kubernetes_io:node_interruption_count{monitored_resource="k8s_node", interruption_reason="HW/SW Maintenance"}[5m]))
+  ```
+- **PromQL Query (Interruption count aggregated by node pool)**:
+  ```promql
+  sum by (node_pool_name,interruption_type,interruption_reason)(sum_over_time(kubernetes_io:node_pool_interruption_count{monitored_resource="k8s_node_pool", interruption_reason="HW/SW Maintenance", node_pool_name="<node_pool_name>"}[5m]))
+  ```
+
+### Step 7: Calculate Recovery and Interruption Metrics [Low Risk] [Auto]
+
+Calculate Mean Time to Recovery (MTTR) and Mean Time Between Interruptions (MTBI) over the last 7 days.
+
+- **PromQL Query (MTTR - Mean Time to Recovery)**:
+  ```promql
+  sum(sum_over_time(kubernetes_io:node_pool_accelerator_times_to_recover_sum{monitored_resource="k8s_node_pool", cluster_name="<cluster_name>"}[7d])) / sum(sum_over_time(kubernetes_io:node_pool_accelerator_times_to_recover_count{monitored_resource="k8s_node_pool",cluster_name="<cluster_name>"}[7d]))
+  ```
+- **PromQL Query (MTBI - Mean Time Between Interruptions)**:
+  ```promql
+  sum(count_over_time(kubernetes_io:node_memory_total_bytes{monitored_resource="k8s_node", node_name=~"gke-tpu.*|gk3-tpu.*", cluster_name="<cluster_name>"}[7d])) / sum(sum_over_time(kubernetes_io:node_interruption_count{monitored_resource="k8s_node", node_name=~"gke-tpu.*|gk3-tpu.*", cluster_name="<cluster_name>"}[7d]))
+  ```
+
+### Step 8: Monitor TPU Host Metrics [Low Risk] [Auto]
+
+For GKE version `1.28.1-gke.1066000` or later, monitor TPU host performance.
+
+- **Container Metrics**:
+  - `kubernetes.io/container/accelerator/tensorcore_utilization`: Current percentage of the TensorCore that is utilized.
+  - `kubernetes.io/container/accelerator/memory_bandwidth_utilization`: Current percentage of the accelerator memory bandwidth that is being used.
+- **Node Metrics**:
+  - `kubernetes.io/node/accelerator/tensorcore_utilization`
+  - `kubernetes.io/node/accelerator/memory_bandwidth_utilization`

--- a/skills/gke-tpu-metrics-monitoring/TEST.md
+++ b/skills/gke-tpu-metrics-monitoring/TEST.md
@@ -1,0 +1,19 @@
+# Manual Test Plan for GKE TPU Metrics Monitoring Skill
+
+This document describes how to manually verify the GKE TPU Metrics Monitoring skill.
+
+## Test Case 1: Verify PromQL Queries in Cloud Monitoring
+
+1.  Go to the Google Cloud Console.
+2.  Navigate to **Monitoring** > **Metrics Explorer**.
+3.  Switch to **MQL** or **PromQL** mode (select PromQL).
+4.  Try running the following query (replace placeholders):
+    ```promql
+    kubernetes_io:node_status_condition{monitored_resource="k8s_node", cluster_name="<your-cluster>", condition="Ready"}
+    ```
+5.  Verify that it returns data if you have GKE system metrics enabled.
+
+## Test Case 2: Verify TPU Duty Cycle Metric
+
+1.  In Metrics Explorer, search for the metric `kubernetes.io/container/accelerator/duty_cycle`.
+2.  Ensure it is visible and shows data for your running TPU workloads (which must have `containerPort: 8431` configured).

--- a/skills/gke-tpu-metrics-monitoring/references/failure_signatures.md
+++ b/skills/gke-tpu-metrics-monitoring/references/failure_signatures.md
@@ -1,0 +1,33 @@
+# GKE TPU Metrics Signatures
+
+This document describes key metric signatures and what they indicate for GKE TPU workloads.
+
+## 1. Node Unready Signature
+
+- **Metric**: `kubernetes.io/node/status_condition`
+- **Signature**: `condition="Ready"`, `status="False"` (or `status="Unknown"`)
+- **Meaning**: The GKE node hosting the TPU is not healthy. Workloads on this node will be disrupted.
+
+## 2. Node Pool Error Signature
+
+- **Metric**: `kubernetes.io/node_pool/status`
+- **Signature**: `status="Error"`
+- **Meaning**: The multi-host TPU node pool has encountered an error (e.g., provisioning failure).
+
+## 3. Node Preemption Signature
+
+- **Metric**: `kubernetes.io/node/interruption_count`
+- **Signature**: `interruption_type="PreemptionEvent"`
+- **Meaning**: The node was preempted (common for Spot VMs). Workload needs to be rescheduled.
+
+## 4. Host Error Signature
+
+- **Metric**: `kubernetes.io/node/interruption_count`
+- **Signature**: `interruption_type="TerminationEvent"`, `interruption_reason="HostError"`
+- **Meaning**: The underlying physical host encountered a hardware error. GKE should trigger AutoRepair.
+
+## 5. Low TPU Utilization Signature
+
+- **Metric**: `kubernetes.io/container/accelerator/duty_cycle` or `kubernetes.io/container/accelerator/tensorcore_utilization`
+- **Signature**: Value `< 0.2` (20%) during active training.
+- **Meaning**: The TPU is heavily underutilized, likely due to data bottleneck or small batch size.

--- a/skills/gke-tpu-metrics-monitoring/scripts/validate_queries.sh
+++ b/skills/gke-tpu-metrics-monitoring/scripts/validate_queries.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Validate Cloud Logging LQL queries used in SKILL.md
+
+set -e
+
+if [ -z "${PROJECT_ID:-}" ]; then
+  echo "Error: PROJECT_ID environment variable must be set explicitly." >&2
+  exit 1
+fi
+
+echo "Using project: $PROJECT_ID"
+
+echo "No Cloud Logging LQL queries defined in this skill to validate."
+echo "✅ Validation skipped (no queries)."


### PR DESCRIPTION
# Pull Request

## Why This Change

Users need a structured way to monitor and troubleshoot GKE TPU workloads using GKE system metrics. This PR translates the official GKE TPU metrics documentation https://docs.cloud.google.com/kubernetes-engine/docs/how-to/tpus#metrics into a reusable AI skill, enabling the agent to diagnose workload interruptions (such as preemptions and host errors) and performance issues (such as low duty cycle/underutilization) using verified PromQL queries.

## What Changed

Created a new skill `gke-tpu-metrics-monitoring` under `skills/`.

**Files:**

- `skills/gke-tpu-metrics-monitoring/SKILL.md`
- `skills/gke-tpu-metrics-monitoring/README.md`
- `skills/gke-tpu-metrics-monitoring/references/failure_signatures.md`
- `skills/gke-tpu-metrics-monitoring/scripts/validate_queries.sh`
- `skills/gke-tpu-metrics-monitoring/TEST.md`
- `skills/gke-tpu-metrics-monitoring/EVAL.yaml`
- `skills/gke-tpu-metrics-monitoring/BUILD`

**Added/Changed/Fixed:**

- Added `gke-tpu-metrics-monitoring` skill containing diagnostic steps for runtime metrics, node status, node pool status, availability, interruptions, TTR, and TBI.
- Added PromQL queries for node status, node pool status, availability, interruptions, TTR, and TBI.
- Added failure signatures for node unready, node pool error, preemption, host error, and low utilization.
- Added a manual test plan and local evaluation cases.

## Why This Matters

### 1. Standardized TPU Diagnostics

- Provides a structured, step-by-step workflow for diagnosing GKE TPU issues using official system metrics.

### 2. Zero-Hallucination PromQL Queries

- Includes only verified PromQL queries from the official GKE documentation, ensuring safety and reliability.

### 3. Evaluation Ready

- Includes `EVAL.yaml` with context-acquisition and grounded-diagnostics cases to track agent performance.

## Context

This skill was created by translating the public GKE documentation: https://cloud.google.com/kubernetes-engine/docs/how-to/tpus#metrics.

## Testing

```bash
# Validated the skill structure and metadata
./dev/ci/presubmits/validate-skills.sh  # Pass

# Ran local skill evaluation