### PR TITLE
feat(skills): Add verify_unused cluster safety check skill

### DIFF
--- a/skills/verify_unused/SKILL.md
+++ b/skills/verify_unused/SKILL.md
@@ -8,6 +8,7 @@ description: Verifies if a GKE or Kubernetes cluster is unused (no active comput
 Use this skill to safety-check whether a GKE or Kubernetes cluster is active or unused **before** executing any cluster deletion commands (`DeleteCluster`, `gcloud container clusters delete`, or `kubectl delete`). This prevents accidental data loss, service interruption, and destruction of active environments.
 
 ## Critical Rule
+
 > [!IMPORTANT]
 > **NEVER** delete a GKE or Kubernetes cluster without running this verification skill first or verifying that `deletion_policy: VERIFY_UNUSED` is enforced. If this check returns `[ACTIVE]` (exit code `1`) or fails due to network/server timeout (`[FAIL-CLOSE]`, exit code `2`), you must **block the deletion** and prompt the user for explicit confirmation or intervention.
 
@@ -16,55 +17,64 @@ Use this skill to safety-check whether a GKE or Kubernetes cluster is active or 
 The safety verification evaluates three core heuristics. If any condition is met, deletion is blocked:
 
 ### 1. External Exposure
-* **Failure Condition:** Presence of $\ge 1$ `Service` of type `LoadBalancer`, OR any `Ingress`, `Gateway` (Gateway API), or `MultiClusterIngress` resource in any namespace.
-* **Rationale:** These resources indicate the cluster is actively serving (or configured to serve) ingress traffic. Deleting the cluster would cause an immediate service disruption for users or connected systems.
+
+- **Failure Condition:** Presence of $\ge 1$ `Service` of type `LoadBalancer`, OR any `Ingress`, `Gateway` (Gateway API), or `MultiClusterIngress` resource in any namespace.
+- **Rationale:** These resources indicate the cluster is actively serving (or configured to serve) ingress traffic. Deleting the cluster would cause an immediate service disruption for users or connected systems.
 
 ### 2. Persistent Data
-* **Failure Condition:** Presence of $\ge 1$ `PersistentVolumeClaim` (PVC) in the `Bound` state in any namespace.
-* **Rationale:** A Bound PVC indicates a persistent disk attached containing application state. Deleting the cluster could result in permanent, unrecoverable data loss.
+
+- **Failure Condition:** Presence of $\ge 1$ `PersistentVolumeClaim` (PVC) in the `Bound` state in any namespace.
+- **Rationale:** A Bound PVC indicates a persistent disk attached containing application state. Deleting the cluster could result in permanent, unrecoverable data loss.
 
 ### 3. Active Compute
-* **Failure Condition:** Presence of $\ge 1$ `Pod` in `Running` or `Pending` state in any user namespace (includes `default`, but excludes system namespaces like `kube-system` or those prefixed with `gke-`).
-* **Rationale:** Running pods represent active compute, and Pending pods indicate a system attempting to schedule or scale work. System namespaces (`kube-system`, `gke-*`) are excluded to avoid blocking deletion on cluster control-plane and addon overhead.
+
+- **Failure Condition:** Presence of $\ge 1$ `Pod` in `Running` or `Pending` state in any user namespace (includes `default`, but excludes system namespaces like `kube-system` or those prefixed with `gke-`).
+- **Rationale:** Running pods represent active compute, and Pending pods indicate a system attempting to schedule or scale work. System namespaces (`kube-system`, `gke-*`) are excluded to avoid blocking deletion on cluster control-plane and addon overhead.
 
 ## Performance Overhead & Reliability
 
 To ensure checks add minimal overhead and operate safely under adverse network conditions:
-* **Low-Overhead Queries (Early Return):** Because the policy only needs to confirm the existence of at least one active resource to block deletion, lists use standard chunk sizes (`--chunk-size=500`) and the Python script terminates immediately upon finding the first offending resource.
+
+- **Low-Overhead Queries (Early Return):** Because the policy only needs to confirm the existence of at least one active resource to block deletion, lists use standard chunk sizes (`--chunk-size=500`) and the Python script terminates immediately upon finding the first offending resource.
   Note that passing `--chunk-size=1` with `kubectl -o json` is avoided because `kubectl` sequentially loops through all pages before formatting output, which causes N sequential API requests.
-* **Bounded Timeouts & Fail-Close Behavior:** Synchronous API queries enforce explicit timeouts (`--request-timeout`).
+- **Bounded Timeouts & Fail-Close Behavior:** Synchronous API queries enforce explicit timeouts (`--request-timeout`).
   If the checks do not complete within the timeout window or encounter API errors, the operation **fails close** (exit code `2`), blocking cluster deletion rather than assuming safety during control-plane latency or outages.
 
 ## Usage Instructions
 
 ### Step 1: Execute Verification Script
+
 Execute the bundled safety verification script (`scripts/verify_unused.py` located inside this skill folder) against the target cluster:
 
 ```bash
 python3 <skill_directory>/scripts/verify_unused.py --timeout 5.0
 ```
 
-*(Optional flags: `--kubeconfig <path>` or `--context <name>` can be passed to target specific environments).*
+_(Optional flags: `--kubeconfig <path>` or `--context <name>` can be passed to target specific environments)._
 
 ### Step 2: Interpret Output & Exit Codes
 
-* **Exit Code `0` (`[UNUSED]`)**:
+- **Exit Code `0` (`[UNUSED]`)**:
+
   ```text
   [UNUSED] Cluster is verified unused (no active compute, exposure, or persistent data).
   It is safe to proceed with cluster deletion.
   ```
-  *Action:* Safe to proceed with cluster deletion.
 
-* **Exit Code `1` (`[ACTIVE]`)**:
+  _Action:_ Safe to proceed with cluster deletion.
+
+- **Exit Code `1` (`[ACTIVE]`)**:
+
   ```text
   [ACTIVE] Cluster is currently in use! Deletion blocked.
   Active workloads/resources detected:
     - External Exposure: Service prod/frontend is of type LoadBalancer
   ```
-  *Action:* **DO NOT delete the cluster.** Stop immediately and present the detected active resources to the user.
 
-* **Exit Code `2` (`[FAIL-CLOSE]`)**:
+  _Action:_ **DO NOT delete the cluster.** Stop immediately and present the detected active resources to the user.
+
+- **Exit Code `2` (`[FAIL-CLOSE]`)**:
   ```text
   [FAIL-CLOSE] Cluster safety check failed due to query error or timeout!
   ```
-  *Action:* **DO NOT delete the cluster.** Stop and report that verification failed close due to query error or API server timeout.
+  _Action:_ **DO NOT delete the cluster.** Stop and report that verification failed close due to query error or API server timeout.

--- a/skills/verify_unused/SKILL.md
+++ b/skills/verify_unused/SKILL.md
@@ -30,8 +30,10 @@ The safety verification evaluates three core heuristics. If any condition is met
 ## Performance Overhead & Reliability
 
 To ensure checks add minimal overhead and operate safely under adverse network conditions:
-* **Low-Overhead Queries (Early Return):** Because the policy only needs to confirm the existence of at least one active resource to block deletion, lists use standard chunk sizes (`--chunk-size=500`) and the Python script terminates immediately upon finding the first offending resource. Note that passing `--chunk-size=1` with `kubectl -o json` is avoided because `kubectl` sequentially loops through all pages before formatting output, which causes N sequential API requests.
-* **Bounded Timeouts & Fail-Close Behavior:** Synchronous API queries enforce explicit timeouts (`--request-timeout`). If the checks do not complete within the timeout window or encounter API errors, the operation **fails close** (exit code `2`), blocking cluster deletion rather than assuming safety during control-plane latency or outages.
+* **Low-Overhead Queries (Early Return):** Because the policy only needs to confirm the existence of at least one active resource to block deletion, lists use standard chunk sizes (`--chunk-size=500`) and the Python script terminates immediately upon finding the first offending resource.
+  Note that passing `--chunk-size=1` with `kubectl -o json` is avoided because `kubectl` sequentially loops through all pages before formatting output, which causes N sequential API requests.
+* **Bounded Timeouts & Fail-Close Behavior:** Synchronous API queries enforce explicit timeouts (`--request-timeout`).
+  If the checks do not complete within the timeout window or encounter API errors, the operation **fails close** (exit code `2`), blocking cluster deletion rather than assuming safety during control-plane latency or outages.
 
 ## Usage Instructions
 
@@ -47,14 +49,14 @@ python3 <skill_directory>/scripts/verify_unused.py --timeout 5.0
 ### Step 2: Interpret Output & Exit Codes
 
 * **Exit Code `0` (`[UNUSED]`)**:
-  ```
+  ```text
   [UNUSED] Cluster is verified unused (no active compute, exposure, or persistent data).
   It is safe to proceed with cluster deletion.
   ```
   *Action:* Safe to proceed with cluster deletion.
 
 * **Exit Code `1` (`[ACTIVE]`)**:
-  ```
+  ```text
   [ACTIVE] Cluster is currently in use! Deletion blocked.
   Active workloads/resources detected:
     - External Exposure: Service prod/frontend is of type LoadBalancer
@@ -62,7 +64,7 @@ python3 <skill_directory>/scripts/verify_unused.py --timeout 5.0
   *Action:* **DO NOT delete the cluster.** Stop immediately and present the detected active resources to the user.
 
 * **Exit Code `2` (`[FAIL-CLOSE]`)**:
-  ```
+  ```text
   [FAIL-CLOSE] Cluster safety check failed due to query error or timeout!
   ```
   *Action:* **DO NOT delete the cluster.** Stop and report that verification failed close due to query error or API server timeout.

--- a/skills/verify_unused/SKILL.md
+++ b/skills/verify_unused/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: verify_unused
+description: Verifies if a GKE or Kubernetes cluster is unused (no active compute, external exposure, or persistent data) before allowing deletion. Evaluates external exposure (LoadBalancer Service, Ingress, Gateway, MultiClusterIngress), persistent data (Bound PVC), and active compute (Running/Pending Pods in user namespaces) with low-overhead queries and fail-close timeouts.
+---
+
+# verify_unused
+
+Use this skill to safety-check whether a GKE or Kubernetes cluster is active or unused **before** executing any cluster deletion commands (`DeleteCluster`, `gcloud container clusters delete`, or `kubectl delete`). This prevents accidental data loss, service interruption, and destruction of active environments.
+
+## Critical Rule
+> [!IMPORTANT]
+> **NEVER** delete a GKE or Kubernetes cluster without running this verification skill first or verifying that `deletion_policy: VERIFY_UNUSED` is enforced. If this check returns `[ACTIVE]` (exit code `1`) or fails due to network/server timeout (`[FAIL-CLOSE]`, exit code `2`), you must **block the deletion** and prompt the user for explicit confirmation or intervention.
+
+## Safety Criteria
+
+The safety verification evaluates three core heuristics. If any condition is met, deletion is blocked:
+
+### 1. External Exposure
+* **Failure Condition:** Presence of $\ge 1$ `Service` of type `LoadBalancer`, OR any `Ingress`, `Gateway` (Gateway API), or `MultiClusterIngress` resource in any namespace.
+* **Rationale:** These resources indicate the cluster is actively serving (or configured to serve) ingress traffic. Deleting the cluster would cause an immediate service disruption for users or connected systems.
+
+### 2. Persistent Data
+* **Failure Condition:** Presence of $\ge 1$ `PersistentVolumeClaim` (PVC) in the `Bound` state in any namespace.
+* **Rationale:** A Bound PVC indicates a persistent disk attached containing application state. Deleting the cluster could result in permanent, unrecoverable data loss.
+
+### 3. Active Compute
+* **Failure Condition:** Presence of $\ge 1$ `Pod` in `Running` or `Pending` state in any user namespace (includes `default`, but excludes system namespaces like `kube-system` or those prefixed with `gke-`).
+* **Rationale:** Running pods represent active compute, and Pending pods indicate a system attempting to schedule or scale work. System namespaces (`kube-system`, `gke-*`) are excluded to avoid blocking deletion on cluster control-plane and addon overhead.
+
+## Performance Overhead & Reliability
+
+To ensure checks add minimal overhead and operate safely under adverse network conditions:
+* **Low-Overhead Queries (Early Return):** Because the policy only needs to confirm the existence of at least one active resource to block deletion, lists use standard chunk sizes (`--chunk-size=500`) and the Python script terminates immediately upon finding the first offending resource. Note that passing `--chunk-size=1` with `kubectl -o json` is avoided because `kubectl` sequentially loops through all pages before formatting output, which causes N sequential API requests.
+* **Bounded Timeouts & Fail-Close Behavior:** Synchronous API queries enforce explicit timeouts (`--request-timeout`). If the checks do not complete within the timeout window or encounter API errors, the operation **fails close** (exit code `2`), blocking cluster deletion rather than assuming safety during control-plane latency or outages.
+
+## Usage Instructions
+
+### Step 1: Execute Verification Script
+Execute the bundled safety verification script (`scripts/verify_unused.py` located inside this skill folder) against the target cluster:
+
+```bash
+python3 <skill_directory>/scripts/verify_unused.py --timeout 5.0
+```
+
+*(Optional flags: `--kubeconfig <path>` or `--context <name>` can be passed to target specific environments).*
+
+### Step 2: Interpret Output & Exit Codes
+
+* **Exit Code `0` (`[UNUSED]`)**:
+  ```
+  [UNUSED] Cluster is verified unused (no active compute, exposure, or persistent data).
+  It is safe to proceed with cluster deletion.
+  ```
+  *Action:* Safe to proceed with cluster deletion.
+
+* **Exit Code `1` (`[ACTIVE]`)**:
+  ```
+  [ACTIVE] Cluster is currently in use! Deletion blocked.
+  Active workloads/resources detected:
+    - External Exposure: Service prod/frontend is of type LoadBalancer
+  ```
+  *Action:* **DO NOT delete the cluster.** Stop immediately and present the detected active resources to the user.
+
+* **Exit Code `2` (`[FAIL-CLOSE]`)**:
+  ```
+  [FAIL-CLOSE] Cluster safety check failed due to query error or timeout!
+  ```
+  *Action:* **DO NOT delete the cluster.** Stop and report that verification failed close due to query error or API server timeout.

--- a/skills/verify_unused/scripts/verify_unused.py
+++ b/skills/verify_unused/scripts/verify_unused.py
@@ -154,7 +154,7 @@ def verify_unused(kubeconfig=None, context=None, timeout_sec=5.0):
     print(f"Error details: {e}")
     print("To prevent accidental cluster deletion during control-plane outages or network latency, deletion is BLOCKED.")
     print("=" * 70)
-    sys.exit(2)
+    return 2
 
   # Final Verdict
   print("=" * 70)
@@ -164,12 +164,12 @@ def verify_unused(kubeconfig=None, context=None, timeout_sec=5.0):
     for reason in active_reasons:
       print(f"  - {reason}")
     print("=" * 70)
-    sys.exit(1)
+    return 1
   else:
     print("\033[92m[UNUSED] Cluster is verified unused (no active compute, exposure, or persistent data).\033[0m")
     print("It is safe to proceed with cluster deletion.")
     print("=" * 70)
-    sys.exit(0)
+    return 0
 
 
 def main():
@@ -191,11 +191,12 @@ def main():
       help="Timeout in seconds for synchronous API queries (defaults to 5.0s).",
   )
   args = parser.parse_args()
-  verify_unused(
+  exit_code = verify_unused(
       kubeconfig=args.kubeconfig,
       context=args.context,
       timeout_sec=args.timeout,
   )
+  sys.exit(exit_code)
 
 
 if __name__ == "__main__":

--- a/skills/verify_unused/scripts/verify_unused.py
+++ b/skills/verify_unused/scripts/verify_unused.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Script to verify if a GKE/Kubernetes cluster is active or unused before deletion.
+
+Evaluates External Exposure, Persistent Data, and Active Compute criteria with
+low-overhead queries (chunking/early return) and fail-close timeout handling.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def run_kubectl(args, timeout_sec=5.0):
+  """Runs a kubectl command and parses its JSON output.
+
+  Handles missing API resource types gracefully (returns None).
+  Enforces request timeouts and fails close on network or API errors.
+  """
+  cmd = [
+      "kubectl",
+  ] + args + [
+      "-o",
+      "json",
+      f"--request-timeout={timeout_sec}s",
+  ]
+  try:
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=timeout_sec + 2.0,
+    )
+    return json.loads(result.stdout)
+  except subprocess.TimeoutExpired as e:
+    raise RuntimeError(
+        f"Kubectl query timed out after {timeout_sec}s"
+    ) from e
+  except subprocess.CalledProcessError as e:
+    err_msg = (e.stderr or "").lower()
+    # Handle resource type not found errors gracefully (e.g., if Gateway or MultiClusterIngress CRDs are not installed)
+    if (
+        "doesn't have a resource type" in err_msg
+        or "not found" in err_msg
+        or "the server could not find the requested resource" in err_msg
+    ):
+      return None
+    raise RuntimeError(
+        f"Kubectl query failed (exit code {e.returncode}): {e.stderr.strip()}"
+    ) from e
+
+
+def verify_unused(kubeconfig=None, context=None, timeout_sec=5.0):
+  base_args = []
+  if kubeconfig:
+    base_args.extend(["--kubeconfig", kubeconfig])
+  if context:
+    base_args.extend(["--context", context])
+
+  active_reasons = []
+
+  print("Evaluating GKE cluster safety criteria...")
+
+  try:
+    # 1. External Exposure Checks
+    # Check Services of type LoadBalancer
+    svcs = run_kubectl(base_args + ["get", "services", "-A", "--chunk-size=500"], timeout_sec=timeout_sec)
+    if svcs:
+      for item in svcs.get("items", []):
+        spec = item.get("spec", {})
+        if spec.get("type") == "LoadBalancer":
+          metadata = item.get("metadata", {})
+          active_reasons.append(
+              f"External Exposure: Service {metadata.get('namespace')}/{metadata.get('name')} is of type LoadBalancer"
+          )
+          break  # Early exit on first active match to minimize processing overhead
+
+    # Check Ingresses
+    if not active_reasons:
+      ingresses = run_kubectl(base_args + ["get", "ingress", "-A", "--chunk-size=500"], timeout_sec=timeout_sec)
+      if ingresses and ingresses.get("items"):
+        metadata = ingresses["items"][0].get("metadata", {})
+        active_reasons.append(
+            f"External Exposure: Active Ingress resource present ({metadata.get('namespace')}/{metadata.get('name')})"
+        )
+
+    # Check Gateways
+    if not active_reasons:
+      gateways = run_kubectl(base_args + ["get", "gateway", "-A", "--chunk-size=500"], timeout_sec=timeout_sec)
+      if gateways and gateways.get("items"):
+        metadata = gateways["items"][0].get("metadata", {})
+        active_reasons.append(
+            f"External Exposure: Active Gateway resource present ({metadata.get('namespace')}/{metadata.get('name')})"
+        )
+
+    # Check MultiClusterIngresses
+    if not active_reasons:
+      mcis = run_kubectl(base_args + ["get", "multiclusteringress", "-A", "--chunk-size=500"], timeout_sec=timeout_sec)
+      if mcis and mcis.get("items"):
+        metadata = mcis["items"][0].get("metadata", {})
+        active_reasons.append(
+            f"External Exposure: Active MultiClusterIngress resource present ({metadata.get('namespace')}/{metadata.get('name')})"
+        )
+
+    # 2. Persistent Data Checks
+    # Check PVCs in Bound state
+    if not active_reasons:
+      pvcs = run_kubectl(base_args + ["get", "pvc", "-A", "--chunk-size=500"], timeout_sec=timeout_sec)
+      if pvcs:
+        for item in pvcs.get("items", []):
+          status = item.get("status", {})
+          if status.get("phase") == "Bound":
+            metadata = item.get("metadata", {})
+            active_reasons.append(
+                f"Persistent Data: PVC {metadata.get('namespace')}/{metadata.get('name')} is in Bound state"
+            )
+            break
+
+    # 3. Active Compute Checks
+    # Check Pods in Running or Pending state in user namespaces (excluding kube-system and gke-*)
+    if not active_reasons:
+      pods = run_kubectl(base_args + ["get", "pods", "-A", "--chunk-size=500"], timeout_sec=timeout_sec)
+      if pods:
+        for item in pods.get("items", []):
+          metadata = item.get("metadata", {})
+          ns = metadata.get("namespace", "default")
+          if ns == "kube-system" or ns.startswith("gke-"):
+            continue
+          status = item.get("status", {})
+          phase = status.get("phase")
+          if phase in ("Running", "Pending"):
+            active_reasons.append(
+                f"Active Compute: Pod {ns}/{metadata.get('name')} is in {phase} state"
+            )
+            break
+
+  except Exception as e:
+    print("=" * 70)
+    print("\033[91m[FAIL-CLOSE] Cluster safety check failed due to query error or timeout!\033[0m")
+    print(f"Error details: {e}")
+    print("To prevent accidental cluster deletion during control-plane outages or network latency, deletion is BLOCKED.")
+    print("=" * 70)
+    sys.exit(2)
+
+  # Final Verdict
+  print("=" * 70)
+  if active_reasons:
+    print("\033[91m[ACTIVE] Cluster is currently in use! Deletion blocked.\033[0m")
+    print("Active workloads/resources detected:")
+    for reason in active_reasons:
+      print(f"  - {reason}")
+    print("=" * 70)
+    sys.exit(1)
+  else:
+    print("\033[92m[UNUSED] Cluster is verified unused (no active compute, exposure, or persistent data).\033[0m")
+    print("It is safe to proceed with cluster deletion.")
+    print("=" * 70)
+    sys.exit(0)
+
+
+def main():
+  parser = argparse.ArgumentParser(
+      description="Verify if a GKE/Kubernetes cluster is unused before deletion."
+  )
+  parser.add_argument(
+      "--kubeconfig",
+      help="Path to the kubeconfig file to use for verification.",
+  )
+  parser.add_argument(
+      "--context",
+      help="Name of the kubeconfig context to verify.",
+  )
+  parser.add_argument(
+      "--timeout",
+      type=float,
+      default=5.0,
+      help="Timeout in seconds for synchronous API queries (defaults to 5.0s).",
+  )
+  args = parser.parse_args()
+  verify_unused(
+      kubeconfig=args.kubeconfig,
+      context=args.context,
+      timeout_sec=args.timeout,
+  )
+
+
+if __name__ == "__main__":
+  main()

--- a/skills/verify_unused/scripts/verify_unused.py
+++ b/skills/verify_unused/scripts/verify_unused.py
@@ -149,23 +149,24 @@ def verify_unused(kubeconfig=None, context=None, timeout_sec=5.0):
             break
 
   except Exception as e:
-    print("=" * 70)
-    print("\033[91m[FAIL-CLOSE] Cluster safety check failed due to query error or timeout!\033[0m")
-    print(f"Error details: {e}")
-    print("To prevent accidental cluster deletion during control-plane outages or network latency, deletion is BLOCKED.")
-    print("=" * 70)
+    print("=" * 70, file=sys.stderr)
+    print("\033[91m[FAIL-CLOSE] Cluster safety check failed due to query error or timeout!\033[0m", file=sys.stderr)
+    print(f"Error details: {e}", file=sys.stderr)
+    print("To prevent accidental cluster deletion during control-plane outages or network latency, deletion is BLOCKED.", file=sys.stderr)
+    print("=" * 70, file=sys.stderr)
     return 2
 
   # Final Verdict
-  print("=" * 70)
   if active_reasons:
-    print("\033[91m[ACTIVE] Cluster is currently in use! Deletion blocked.\033[0m")
-    print("Active workloads/resources detected:")
+    print("=" * 70, file=sys.stderr)
+    print("\033[91m[ACTIVE] Cluster is currently in use! Deletion blocked.\033[0m", file=sys.stderr)
+    print("Active workloads/resources detected:", file=sys.stderr)
     for reason in active_reasons:
-      print(f"  - {reason}")
-    print("=" * 70)
+      print(f"  - {reason}", file=sys.stderr)
+    print("=" * 70, file=sys.stderr)
     return 1
   else:
+    print("=" * 70)
     print("\033[92m[UNUSED] Cluster is verified unused (no active compute, exposure, or persistent data).\033[0m")
     print("It is safe to proceed with cluster deletion.")
     print("=" * 70)

--- a/skills/verify_unused/scripts/verify_unused.py
+++ b/skills/verify_unused/scripts/verify_unused.py
@@ -60,7 +60,7 @@ def run_kubectl(args, timeout_sec=5.0):
     ):
       return None
     raise RuntimeError(
-        f"Kubectl query failed (exit code {e.returncode}): {e.stderr.strip()}"
+        f"Kubectl query failed (exit code {e.returncode}): {(e.stderr or '').strip()}"
     ) from e
 
 


### PR DESCRIPTION
# Pull Request

## Why This Change

When AI agents or engineers manage Kubernetes clusters, executing cluster deletion commands carries significant risk of destroying active workloads or persistent application state. AI agents operating across CLI and tool surfaces need a standardized, portable agent skill (verify_unused) to evaluate active compute, persistent data, and external exposure heuristics before allowing any cluster deletion operation to proceed.



## What Changed

Added the verify_unused skill under the skills/verify_unused/ directory adhering to repository structure standards and pre-deletion safety criteria.

**Files:**

- skills/verify_unused/SKILL.md
- skills/verify_unused/scripts/verify_unused.py

**Added/Changed/Fixed:**

- Added SKILL.md: Provides standardized guidance on cluster deletion heuristics, critical rules against deleting unverified clusters, and portable execution instructions (python3 <skill_directory>/scripts/verify_unused.py).
- Added scripts/verify_unused.py: Python script evaluating:
   - External Exposure: Detects Services of type LoadBalancer, or any active Ingress, Gateway, or MultiClusterIngress.
   - Persistent Data: Detects any PersistentVolumeClaim (PVC) in the Bound state.
   - Active Compute: Detects Pod resources in Running or Pending states within user namespaces (excluding kube-system and gke-*).
- Performance & Reliability Optimization: Implemented standard chunking (--chunk-size=500) and client-side early-return (break) upon detecting the first offending resource to minimize query overhead without triggering kubectl -o json pagination amplification (which would occur with --chunk-size=1).
- Fail-Close Behavior: Added configurable query timeouts (--timeout=5.0) that block deletion (exit code 2) if cluster queries fail or time out due to control-plane latency.

## Why This Matters

### 1. Prevention of Unrecoverable Data Loss & Outages
Enforces pre-deletion evaluation against Bound PVCs and exposed ingress controllers, stopping agents from accidentally wiping stateful application data or disrupting production traffic serving.

### 2. Low Overhead & Pagination Safety
By avoiding --chunk-size=1 on kubectl -o json calls and relying on client-side early break loop termination, the skill minimizes API server load while preventing 
N
N-sequential request latencies that cause false-positive query timeouts.

### 3. Fail-Close Reliability
Ensures that network timeouts, API server outages, or unverified states fail closed (blocking deletion) rather than assuming an unreachable cluster is unused and safe to destroy.

-

## Context

<!-- Include related issues, PRs, follow-up work, or other background. -->

## Testing

./dev/tasks/presubmit.sh  # Pass
# List the relevant checks you ran and their results:
 - Go unit tests and package verification: PASSED (pkg/install tests ok)
 - python3 skills/verify_unused/scripts/verify_unused.py --help: PASSED