### PR TITLE
feat(evals): add comprehensive multi-case evaluation suite for JobSet interruption troubleshooting

### DIFF
--- a/skills/gke-ai-troubleshooting-jobset-interruption/evals/faulty_physical_host_detected/task.yaml
+++ b/skills/gke-ai-troubleshooting-jobset-interruption/evals/faulty_physical_host_detected/task.yaml
@@ -1,0 +1,15 @@
+name: "faulty_physical_host_detected"
+
+prompt: >
+  Please triage why 'training-job' (namespace: 'default') is crashing and experiencing downtime
+  in project 'my-project', cluster 'my-cluster', location 'us-central1-a' at timestamp 2026-05-20T08:15:00Z.
+
+expected_output: |
+  The agent must:
+  - Calculate the query window [2026-05-20T07:45:00Z] to [2026-05-20T08:45:00Z].
+  - Query JobSet restarts (find restarts) and check nodepool interruptions (find normal).
+  - Use 'monitoring_time_series_chart' or 'query_logs' to identify node unreadiness (Ready=False) on active nodes.
+  - Use 'monitoring_time_series_chart' to query 'kubernetes.io/node/cpu/total_cores' grouped by 'metadata.user.gce_topology_host' to correlate nodes to GCE physical host IDs.
+  - Conclude that multiple node failures correlate to the same GCE physical host ID (faulty host).
+  - Recommend cordoning/draining the affected nodes, deleting GCE VM instances to trigger recreation on healthy hardware.
+  - Explicitly state that it requires user confirmation before taking any action to cordon/drain nodes or delete instances.

--- a/skills/gke-ai-troubleshooting-jobset-interruption/evals/missing_context/task.yaml
+++ b/skills/gke-ai-troubleshooting-jobset-interruption/evals/missing_context/task.yaml
@@ -1,0 +1,10 @@
+name: "missing_context"
+
+prompt: >
+  Please troubleshoot why our GKE JobSet workload 'training-job' keeps restarting in our cluster.
+
+expected_output: |
+  The agent must:
+  - Identify that required mandatory context (Project ID, GKE Cluster Name, or Location/Region) is missing.
+  - Ask the user to provide the missing required parameters.
+  - Do NOT call any diagnostic tools (like 'monitoring_time_series_chart' or 'query_logs') with empty, guessed, or placeholder parameters.

--- a/skills/gke-ai-troubleshooting-jobset-interruption/evals/no_active_nodes_fallback_or_clean_telemetry/task.yaml
+++ b/skills/gke-ai-troubleshooting-jobset-interruption/evals/no_active_nodes_fallback_or_clean_telemetry/task.yaml
@@ -1,0 +1,13 @@
+name: "no_active_nodes_fallback_or_clean_telemetry"
+
+prompt: >
+  Please check infrastructure metrics for 'training-job' (namespace: 'default') historical failures
+  in project 'my-project', cluster 'my-cluster', location 'us-central1-a' at timestamp 2026-05-20T08:15:00Z.
+
+expected_output: |
+  The agent must:
+  - Calculate the query window [2026-05-20T07:45:00Z] to [2026-05-20T08:45:00Z].
+  - Use 'monitoring_time_series_chart' to query JobSet restarts and confirm restarts occurred.
+  - Query assigned nodes/nodepools and find none (no active nodes/nodepools discovered).
+  - Query unschedulable pod count and confirm pending pods count is 0.
+  - Suggest inspecting application container logs or tracebacks as a fallback since no infrastructure-level node failures or resource exhaustion were found.

--- a/skills/gke-ai-troubleshooting-jobset-interruption/evals/no_jobset_restarts_detected/task.yaml
+++ b/skills/gke-ai-troubleshooting-jobset-interruption/evals/no_jobset_restarts_detected/task.yaml
@@ -1,0 +1,13 @@
+name: "no_jobset_restarts_detected"
+
+prompt: >
+  Please check if there are any interruption issues with our GKE JobSet workload 'training-job' (namespace: 'default')
+  in project 'my-project', cluster 'my-cluster', location 'us-central1-a' at timestamp 2026-05-20T08:15:00Z.
+
+expected_output: |
+  The agent must:
+  - Calculate the query window as [2026-05-20T07:45:00Z] to [2026-05-20T08:45:00Z].
+  - Use the 'monitoring_time_series_chart' tool to check JobSet restarts via the metric 'prometheus.googleapis.com/kube_jobset_restarts/gauge' (or equivalent PromQL).
+  - Report that no restart attempts or count increases were detected.
+  - Conclude that the workload is stable and immediately terminate the investigation.
+  - Do NOT call other node-level or pod-level diagnostic tools.

--- a/skills/gke-ai-troubleshooting-jobset-interruption/evals/single_node_unready_no_host_correlation/task.yaml
+++ b/skills/gke-ai-troubleshooting-jobset-interruption/evals/single_node_unready_no_host_correlation/task.yaml
@@ -1,0 +1,14 @@
+name: "single_node_unready_no_host_correlation"
+
+prompt: >
+  Please investigate training-job (namespace: 'default') in project 'my-project', cluster 'my-cluster', location 'us-central1-a'
+  at timestamp 2026-05-20T08:15:00Z. Notice one node recently went down.
+
+expected_output: |
+  The agent must:
+  - Calculate the query window [2026-05-20T07:45:00Z] to [2026-05-20T08:45:00Z].
+  - Query JobSet restarts (find restarts) and check nodepool interruptions (find normal).
+  - Use 'monitoring_time_series_chart' or 'query_logs' to identify that an active node went unready.
+  - Query node-to-host topology mapping and confirm that node failures do not correlate to the same physical host ID (no multiple nodes failing on same physical host).
+  - Do NOT recommend quarantining physical host VMs.
+  - Continue to check pod/container status or unschedulable pod count.

--- a/skills/gke-ai-troubleshooting-jobset-interruption/evals/spot_preemption_detected/task.yaml
+++ b/skills/gke-ai-troubleshooting-jobset-interruption/evals/spot_preemption_detected/task.yaml
@@ -1,0 +1,15 @@
+name: "spot_preemption_detected"
+
+prompt: >
+  Please troubleshoot why our GKE JobSet workload 'training-job' (namespace: 'default') keeps restarting
+  in project 'my-project', cluster 'my-cluster', location 'us-central1-a' at timestamp 2026-05-20T08:15:00Z.
+  Note: This cluster runs on Spot VM node pools.
+
+expected_output: |
+  The agent must:
+  - Calculate the query window [2026-05-20T07:45:00Z] to [2026-05-20T08:45:00Z].
+  - Use 'monitoring_time_series_chart' to query JobSet restarts and confirm restarts occurred.
+  - Use 'monitoring_time_series_chart' to query nodepool interruptions (using 'kubernetes.io/node_pool/interruption_count') and identify preemption/maintenance events.
+  - Attribute the root cause to Spot VM preemption.
+  - Recommend migrating the critical workload to GKE Reserved/On-Demand VM nodepools or using Compact Placement Policies.
+  - Do NOT recommend cordoning/draining nodes or quarantining physical hosts in this scenario.

--- a/skills/gke-ai-troubleshooting-jobset-interruption/evals/unschedulable_pods_resource_exhaustion/task.yaml
+++ b/skills/gke-ai-troubleshooting-jobset-interruption/evals/unschedulable_pods_resource_exhaustion/task.yaml
@@ -1,0 +1,12 @@
+name: "unschedulable_pods_resource_exhaustion"
+
+prompt: >
+  Our JobSet workload 'training-job' (namespace: 'default') restarted and is now stuck failing to run
+  in project 'my-project', cluster 'my-cluster', location 'us-central1-a' at timestamp 2026-05-20T08:15:00Z.
+
+expected_output: |
+  The agent must:
+  - Calculate the query window [2026-05-20T07:45:00Z] to [2026-05-20T08:45:00Z].
+  - Check JobSet restarts (find restarts), nodepool interruptions (find normal), and node health (find all healthy).
+  - Use 'monitoring_time_series_chart' to query pod status (MQL: 'kubernetes.io/pod/status/unschedulable') and find unschedulable pod count > 0.
+  - Diagnose that the workload is blocked by cluster resource exhaustion or GKE scheduling capacity limits.


### PR DESCRIPTION
# Pull Request

## Why This Change

Adds a structured, automated evaluation suite for the JobSet Interruption troubleshooting skill to test the agent's compliance and accuracy across different infrastructure-level and application-level failure scenarios. 

## What Changed

Added 7 evaluation task files under `skills/gke-ai-troubleshooting-jobset-interruption/evals/` corresponding to the playbooks defined in the skill specification:

**Files:**
- `skills/gke-ai-troubleshooting-jobset-interruption/evals/missing_context/task.yaml`
- `skills/gke-ai-troubleshooting-jobset-interruption/evals/no_jobset_restarts_detected/task.yaml`
- `skills/gke-ai-troubleshooting-jobset-interruption/evals/spot_preemption_detected/task.yaml`
- `skills/gke-ai-troubleshooting-jobset-interruption/evals/faulty_physical_host_detected/task.yaml`
- `skills/gke-ai-troubleshooting-jobset-interruption/evals/unschedulable_pods_resource_exhaustion/task.yaml`
- `skills/gke-ai-troubleshooting-jobset-interruption/evals/no_active_nodes_fallback_or_clean_telemetry/task.yaml`
- `skills/gke-ai-troubleshooting-jobset-interruption/evals/single_node_unready_no_host_correlation/task.yaml`

**Added/Changed/Fixed:**
- **`missing_context`**: Verifies that the agent correctly halts and requests mandatory context (Project ID, Cluster Name, Location, etc.) instead of executing tools with empty arguments.
- **`no_jobset_restarts_detected`**: Verifies that the agent terminates the investigation early and reports a stable workload when no restarts are observed.
- **`spot_preemption_detected`**: Tests diagnosis of Spot VM preemption and verifies recommendation of On-Demand migration.
- **`faulty_physical_host_detected`**: Tests GCE physical host correlation across GKE node failures, and ensures the agent strictly requires explicit user confirmation before executing any cordon/drain operations.
- **`unschedulable_pods_resource_exhaustion`**: Tests diagnosis of unschedulable pending pods due to cluster resource limits.
- **`no_active_nodes_fallback`**: Verifies fallback recommendations to check application container logs/tracebacks when no nodes or nodepools are assigned.
- **`single_node_unready_no_host_correlation`**: Verifies that node failures are not misdiagnosed as physical host faults if they do not correlate to the same physical host GCE VM.

## Why This Matters

### 1. Standardized Directory-Based Design
This adopts the repository's directory-based multi-case design, ensuring compatibility with cloud CI executors without needing to generate temp files.

### 2. Faster Local Debugging
Developers can execute individual `task.yaml` files during troubleshooting or refactoring instead of running the entire suite.

## Testing

```bash
./dev/ci/presubmits/validate-skills.sh  # Pass