### PR TITLE
docs: fix markdown variable rendering and escaping in GPU/TPU disruption skill

### DIFF
--- a/skills/gke-ai-troubleshooting-handle-disruption-gpu-tpu/SKILL.md
+++ b/skills/gke-ai-troubleshooting-handle-disruption-gpu-tpu/SKILL.md
@@ -9,8 +9,8 @@ description: Diagnose and predict node disruption during Compute Engine host mai
 
 ### Step 0: Context Acquisition
 
-- **Mandatory**: <project_id>, <location>, <cluster_name>, <timestamp>.
-- **Optional**: <node_name>, <workload_name>, <workload_namespace>, <nodepool_name>.
+- **Mandatory**: `project_id`, `location`, `cluster_name`, `timestamp`.
+- **Optional**: `node_name`, `workload_name`, `workload_namespace`, `nodepool_name`.
 
 ### Step 1: [Low Risk] Check for Upcoming Scheduled Maintenance
 


### PR DESCRIPTION
# Pull Request

## Why This Change

The mandatory and optional parameter variables in the `Context Acquisition` section were wrapped in raw angle brackets `<...>` (e.g., `<location>`, `<timestamp>`). Most Markdown and HTML renderers (including GitHub previews and chat clients) interpret raw angle brackets as HTML tags, causing them to be hidden or stripped from the rendered view. 

This change wraps them in backticks and removes the angle brackets to ensure they render correctly in all Markdown previews.

## What Changed

**Files:**
- `skills/gke-ai-troubleshooting-handle-disruption-gpu-tpu/SKILL.md`

**Added/Changed/Fixed:**
- Replaced raw angle brackets with backticks for mandatory parameters (`project_id`, `location`, `cluster_name`, `timestamp`) and optional parameters (`node_name`, `workload_name`, `workload_namespace`, `nodepool_name`).

## Why This Matters

### 1. Correct Rendering in Previews
Prevents parameter variables from disappearing in rendered Markdown views on GitHub, internal preview tools, and chat components.

### 2. Standardization
Aligns the parameter descriptions with standard developer documentation style (representing structured variables as inline code using backticks).

## Testing

```bash
./dev/ci/presubmits/validate-skills.sh  # Pass