### PR TITLE
fix(linter): fix formatting and security warnings from golangci-lint

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -123,7 +123,6 @@ func (c *Config) MockCase() string {
 	return BuildMockCase
 }
 
-
 // New constructs a Config populated from gcloud and build version.
 func New(version string, enableDeleteTools bool) *Config {
 	provider := os.Getenv("GKE_MCP_PROVIDER")

--- a/pkg/tools/registry/registry.go
+++ b/pkg/tools/registry/registry.go
@@ -76,7 +76,7 @@ func RegisterTool[In, Out any](
 //
 // If the scenario coordinates cannot be resolved or the mock data file is missing,
 // it returns a structured failure indicating missing mock details.
-func handleMockToolCall(ctx context.Context, toolName string, args any, c *config.Config) (*mcp.CallToolResult, any, error) {
+func handleMockToolCall(_ context.Context, toolName string, args any, c *config.Config) (*mcp.CallToolResult, any, error) {
 	var envSkill, envCaseName, mockDir string
 
 	if c != nil {
@@ -113,7 +113,7 @@ func handleMockToolCall(ctx context.Context, toolName string, args any, c *confi
 
 	// Load mock_data/<skill>/<caseName>.json
 	mockPath := filepath.Join(mockDir, skill, caseName+".json")
-	// #nosec G304
+	// #nosec G304, G703
 	mockBytes, err := os.ReadFile(mockPath)
 	if err != nil {
 		return &mcp.CallToolResult{

--- a/pkg/tools/registry/registry.go
+++ b/pkg/tools/registry/registry.go
@@ -24,8 +24,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 var (
@@ -113,6 +113,7 @@ func handleMockToolCall(ctx context.Context, toolName string, args any, c *confi
 
 	// Load mock_data/<skill>/<caseName>.json
 	mockPath := filepath.Join(mockDir, skill, caseName+".json")
+	// #nosec G304
 	mockBytes, err := os.ReadFile(mockPath)
 	if err != nil {
 		return &mcp.CallToolResult{

--- a/pkg/tools/registry/registry_test.go
+++ b/pkg/tools/registry/registry_test.go
@@ -112,7 +112,7 @@ func TestHandleMockToolCall_EndToEnd(t *testing.T) {
 	// Set up temporary mock_data directory structure
 	tempDir := t.TempDir()
 	skillDir := filepath.Join(tempDir, "my-skill")
-	if err := os.MkdirAll(skillDir, 0755); err != nil {
+	if err := os.MkdirAll(skillDir, 0750); err != nil {
 		t.Fatalf("failed to create skill dir: %v", err)
 	}
 
@@ -125,7 +125,7 @@ func TestHandleMockToolCall_EndToEnd(t *testing.T) {
 		]
 	}`
 	mockFilePath := filepath.Join(skillDir, "my_test_case.json")
-	if err := os.WriteFile(mockFilePath, []byte(caseMockContent), 0644); err != nil {
+	if err := os.WriteFile(mockFilePath, []byte(caseMockContent), 0600); err != nil {
 		t.Fatalf("failed to write mock file: %v", err)
 	}
 
@@ -233,12 +233,12 @@ func TestHandleMockToolCall_EndToEnd(t *testing.T) {
 func TestRegisterTool_MockModeToggle(t *testing.T) {
 	tempDir := t.TempDir()
 	skillDir := filepath.Join(tempDir, "my-skill")
-	if err := os.MkdirAll(skillDir, 0755); err != nil {
+	if err := os.MkdirAll(skillDir, 0750); err != nil {
 		t.Fatalf("failed to create skill dir: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(skillDir, "my_case.json"), []byte(`{
 		"query_logs": [{"query_contains": "error", "response": "mock response"}]
-	}`), 0644); err != nil {
+	}`), 0600); err != nil {
 		t.Fatalf("failed to write mock file: %v", err)
 	}
 
@@ -280,7 +280,7 @@ func TestRegisterTool_MockModeToggle(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to connect client: %v", err)
 		}
-		defer session.Close()
+		defer func() { _ = session.Close() }()
 
 		res, err := session.CallTool(ctx, &mcp.CallToolParams{
 			Name: "query_logs",
@@ -337,7 +337,7 @@ func TestRegisterTool_MockModeToggle(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to connect client: %v", err)
 		}
-		defer session.Close()
+		defer func() { _ = session.Close() }()
 
 		res, err := session.CallTool(ctx, &mcp.CallToolParams{
 			Name: "query_logs",
@@ -388,7 +388,7 @@ func TestRegisterTool_MockModeToggle(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to connect client: %v", err)
 		}
-		defer session.Close()
+		defer func() { _ = session.Close() }()
 
 		res, err := session.CallTool(ctx, &mcp.CallToolParams{
 			Name: "query_logs",

--- a/pkg/tools/registry/registry_test.go
+++ b/pkg/tools/registry/registry_test.go
@@ -254,7 +254,7 @@ func TestRegisterTool_MockModeToggle(t *testing.T) {
 
 	t.Run("production mode delegates to prod handler", func(t *testing.T) {
 		prodHandlerCalled := false
-		prodHandler := func(ctx context.Context, req *mcp.CallToolRequest, args dummyArgs) (*mcp.CallToolResult, any, error) {
+		prodHandler := func(_ context.Context, _ *mcp.CallToolRequest, _ dummyArgs) (*mcp.CallToolResult, any, error) {
 			prodHandlerCalled = true
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: "prod response"}},
@@ -308,7 +308,7 @@ func TestRegisterTool_MockModeToggle(t *testing.T) {
 
 	t.Run("mock mode intercepts call", func(t *testing.T) {
 		prodHandlerCalled := false
-		prodHandler := func(ctx context.Context, req *mcp.CallToolRequest, args dummyArgs) (*mcp.CallToolResult, any, error) {
+		prodHandler := func(_ context.Context, _ *mcp.CallToolRequest, _ dummyArgs) (*mcp.CallToolResult, any, error) {
 			prodHandlerCalled = true
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: "prod response"}},
@@ -365,7 +365,7 @@ func TestRegisterTool_MockModeToggle(t *testing.T) {
 
 	t.Run("nil config safely delegates to prod handler", func(t *testing.T) {
 		prodHandlerCalled := false
-		prodHandler := func(ctx context.Context, req *mcp.CallToolRequest, args dummyArgs) (*mcp.CallToolResult, any, error) {
+		prodHandler := func(_ context.Context, _ *mcp.CallToolRequest, _ dummyArgs) (*mcp.CallToolResult, any, error) {
 			prodHandlerCalled = true
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: "prod response"}},


### PR DESCRIPTION
# Pull Request

## Why This Change

The merge of PR #468 introduced several linter and formatting failures on the `main` branch. This PR addresses and fixes these issues to restore the CI build status on `main` to green.

## What Changed

Fixed issues related to file/directory permissions, unchecked error return values, and code formatting.

**Files:**

- `pkg/config/config.go`
- `pkg/tools/registry/registry.go`
- `pkg/tools/registry/registry_test.go`

**Added/Changed/Fixed:**

- **Fixed (Formatting)**: Re-formatted `config.go` (removed extra newline) and `registry.go` (reordered imports) to resolve `verify-format` failures.
- **Fixed (gosec G304)**: Added `// #nosec G304` to `registry.go` before `os.ReadFile(mockPath)`. The inputs are already strictly validated using `safeNameRegex` to prevent path traversal, making this warning a false positive.
- **Fixed (gosec G301/G306)**: Restriced directory permissions from `0755` to `0750` in `os.MkdirAll`, and file write permissions from `0644` to `0600` in `os.WriteFile` within `registry_test.go`.
- **Fixed (errcheck)**: Wrapped `session.Close()` with `defer func() { _ = session.Close() }()` in `registry_test.go` to explicitly ignore the returned error and satisfy the linter.

## Why This Matters

### 1. Restore CI Build Health
- Fixes the post-merge linter blockages on `main`, ensuring subsequent PRs are not affected by historical check failures.

### 2. Adhere to Security Best Practices
- Restricts overly permissive directories/files created during tests, resolving scanner warnings (G301/G306).

### 3. Improve Code Quality
- Standardizes resource cleanup in tests by explicitly ignoring close errors rather than leaving them unhandled.

## Context

- Post-merge fix for failures introduced in PR #468.

## Testing

```bash
go test ./... # Pass