### PR TITLE
feat(monitoring): add query_prometheus tool for PromQL metric queries

### DIFF
--- a/pkg/tools/monitoring/monitoring.go
+++ b/pkg/tools/monitoring/monitoring.go
@@ -17,6 +17,8 @@ package monitoring
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"log"
 	"strings"
@@ -24,18 +26,28 @@ import (
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	monitoringpb "cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/registry"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"google.golang.org/api/iterator"
+	monitoringv1 "google.golang.org/api/monitoring/v1"
 	"google.golang.org/api/option"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
 type handlers struct {
-	c *config.Config
+	c        *config.Config
+	endpoint string
 }
 
 type listMonitoredResourceDescriptorsArgs struct {
 	ProjectID string `json:"project_id,omitempty" jsonschema:"GCP project ID. Use the default if the user doesn't provide it."`
+}
+
+type queryPrometheusArgs struct {
+	ProjectID string `json:"project_id" jsonschema:"Required. GCP project ID."`
+	Query     string `json:"query" jsonschema:"Required. PromQL query string."`
+	Time      string `json:"time,omitempty" jsonschema:"Optional. Evaluation time (RFC3339 or unix timestamp)."`
+	Timeout   string `json:"timeout,omitempty" jsonschema:"Optional. Query timeout (e.g., '10s')."`
 }
 
 // Install registers monitoring tools with the MCP server.
@@ -51,6 +63,14 @@ func Install(_ context.Context, s *mcp.Server, c *config.Config) error {
 			ReadOnlyHint: true,
 		},
 	}, h.listMRDescriptor)
+
+	registry.RegisterTool(s, c, &mcp.Tool{
+		Name:        "query_prometheus",
+		Description: "Query Cloud Monitoring metrics using PromQL (instant query). Returns Prometheus-compatible JSON response.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+	}, h.queryPrometheus)
 
 	return nil
 }
@@ -90,6 +110,70 @@ func (h *handlers) listMRDescriptor(ctx context.Context, _ *mcp.CallToolRequest,
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			&mcp.TextContent{Text: builder.String()},
+		},
+	}, nil, nil
+}
+
+func (h *handlers) queryPrometheus(ctx context.Context, _ *mcp.CallToolRequest, args *queryPrometheusArgs) (*mcp.CallToolResult, any, error) {
+	if args.ProjectID == "" {
+		return nil, nil, fmt.Errorf("project_id argument cannot be empty")
+	}
+	if args.Query == "" {
+		return nil, nil, fmt.Errorf("query argument cannot be empty")
+	}
+
+	opts := []option.ClientOption{
+		option.WithUserAgent(h.c.UserAgent()),
+	}
+	if h.endpoint != "" {
+		opts = append(opts, option.WithEndpoint(h.endpoint), option.WithoutAuthentication())
+	}
+
+	svc, err := monitoringv1.NewService(ctx, opts...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create monitoring service: %w", err)
+	}
+
+	req := &monitoringv1.QueryInstantRequest{
+		Query:   args.Query,
+		Time:    args.Time,
+		Timeout: args.Timeout,
+	}
+
+	resp, err := svc.Projects.Location.Prometheus.Api.V1.Query("projects/"+args.ProjectID, "global", req).Context(ctx).Do()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to query prometheus metrics: %w", err)
+	}
+
+	if resp != nil && resp.Data != nil {
+		if str, ok := resp.Data.(string); ok {
+			decoded, err := base64.StdEncoding.DecodeString(str)
+			if err == nil {
+				return &mcp.CallToolResult{
+					Content: []mcp.Content{
+						&mcp.TextContent{Text: string(decoded)},
+					},
+				}, nil, nil
+			}
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: str},
+				},
+			}, nil, nil
+		}
+		bytes, err := json.Marshal(resp.Data)
+		if err == nil {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: string(bytes)},
+				},
+			}, nil, nil
+		}
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: "{}"},
 		},
 	}, nil, nil
 }

--- a/pkg/tools/monitoring/monitoring_test.go
+++ b/pkg/tools/monitoring/monitoring_test.go
@@ -15,7 +15,16 @@
 package monitoring
 
 import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func TestListMonitoredResourceDescriptorsArgs_Fields(t *testing.T) {
@@ -78,5 +87,161 @@ func TestListMonitoredResourceDescriptorsArgs_WithProjectNumber(t *testing.T) {
 
 	if args.ProjectID != "123456789012" {
 		t.Errorf("ProjectID = %s, want 123456789012", args.ProjectID)
+	}
+}
+
+func TestQueryPrometheus_ValidationErrors(t *testing.T) {
+	ctx := context.Background()
+
+	// Test 1: Empty project ID
+	hNoProj := &handlers{
+		c: config.NewTestConfig("", "", "test", "test"),
+	}
+	_, _, err := hNoProj.queryPrometheus(ctx, nil, &queryPrometheusArgs{ProjectID: "", Query: "up"})
+	if err == nil || !strings.Contains(err.Error(), "project_id argument cannot be empty") {
+		t.Fatalf("Expected project_id error, got: %v", err)
+	}
+
+	// Test 2: Empty query
+	hWithProj := &handlers{
+		c: config.NewTestConfig("test-project", "", "test", "test"),
+	}
+	_, _, err = hWithProj.queryPrometheus(ctx, nil, &queryPrometheusArgs{ProjectID: "test-project", Query: ""})
+	if err == nil || !strings.Contains(err.Error(), "query argument cannot be empty") {
+		t.Fatalf("Expected query error, got: %v", err)
+	}
+}
+
+func TestQueryPrometheus_Success_Base64EncodedData(t *testing.T) {
+	ctx := context.Background()
+
+	expectedPromData := `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"up"},"value":[1700000000,"1"]}]}}`
+	base64Data := base64.StdEncoding.EncodeToString([]byte(expectedPromData))
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "projects/test-project/location/global/prometheus/api/v1/query") {
+			t.Errorf("Unexpected request URL path: %s", r.URL.Path)
+		}
+		respMap := map[string]any{
+			"contentType": "application/json",
+			"data":        base64Data,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(respMap)
+	}))
+	defer ts.Close()
+
+	h := &handlers{
+		c:        config.NewTestConfig("test-project", "us-central1", "test", "test"),
+		endpoint: ts.URL,
+	}
+
+	res, _, err := h.queryPrometheus(ctx, nil, &queryPrometheusArgs{
+		ProjectID: "test-project",
+		Query:     "up",
+	})
+	if err != nil {
+		t.Fatalf("queryPrometheus returned unexpected error: %v", err)
+	}
+
+	if len(res.Content) == 0 {
+		t.Fatal("Expected non-empty Content in result")
+	}
+
+	textContent, ok := res.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("Expected *mcp.TextContent, got %T", res.Content[0])
+	}
+
+	if textContent.Text != expectedPromData {
+		t.Errorf("Got output:\n%s\nWant:\n%s", textContent.Text, expectedPromData)
+	}
+}
+
+func TestQueryPrometheus_Success_RawMapData(t *testing.T) {
+	ctx := context.Background()
+
+	expectedMapData := map[string]any{
+		"status": "success",
+		"data": map[string]any{
+			"resultType": "vector",
+			"result":     []any{},
+		},
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		respMap := map[string]any{
+			"contentType": "application/json",
+			"data":        expectedMapData,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(respMap)
+	}))
+	defer ts.Close()
+
+	h := &handlers{
+		c:        config.NewTestConfig("test-project", "us-central1", "test", "test"),
+		endpoint: ts.URL,
+	}
+
+	res, _, err := h.queryPrometheus(ctx, nil, &queryPrometheusArgs{
+		ProjectID: "test-project",
+		Query:     "up",
+	})
+	if err != nil {
+		t.Fatalf("queryPrometheus returned unexpected error: %v", err)
+	}
+
+	if len(res.Content) == 0 {
+		t.Fatal("Expected non-empty Content in result")
+	}
+
+	textContent, ok := res.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("Expected *mcp.TextContent, got %T", res.Content[0])
+	}
+
+	if !strings.Contains(textContent.Text, `"status":"success"`) {
+		t.Errorf("Output does not contain status success: %s", textContent.Text)
+	}
+}
+
+func TestQueryPrometheus_APIError(t *testing.T) {
+	ctx := context.Background()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"code":500,"message":"internal server error"}}`))
+	}))
+	defer ts.Close()
+
+	h := &handlers{
+		c:        config.NewTestConfig("test-project", "us-central1", "test", "test"),
+		endpoint: ts.URL,
+	}
+
+	_, _, err := h.queryPrometheus(ctx, nil, &queryPrometheusArgs{
+		ProjectID: "test-project",
+		Query:     "up",
+	})
+	if err == nil {
+		t.Fatal("Expected error for HTTP 500 response, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to query prometheus metrics") {
+		t.Errorf("Unexpected error message: %v", err)
+	}
+}
+
+func TestInstall_QueryPrometheusRegistered(t *testing.T) {
+	ctx := context.Background()
+	s := mcp.NewServer(&mcp.Implementation{
+		Name:    "test-server",
+		Version: "1.0.0",
+	}, nil)
+	c := config.NewTestConfig("test-project", "us-central1", "test", "test")
+
+	err := Install(ctx, s, c)
+	if err != nil {
+		t.Fatalf("Install returned error: %v", err)
 	}
 }


### PR DESCRIPTION
# Pull Request

## Why This Change

Adds a new MCP tool `query_prometheus` to `gke-mcp` to enable PromQL metric queries against Google Cloud Monitoring (`monitoringv1.ProjectsLocationPrometheusApiV1Service`). Currently, `gke-mcp` lacks metric querying capabilities, preventing AI troubleshooting agents from evaluating metrics (e.g., detecting host maintenance events via `kubernetes_io:node_interruption_count`).

## What Changed

**Files:**

- `pkg/tools/monitoring/monitoring.go`
- `pkg/tools/monitoring/monitoring_test.go`

**Added/Changed/Fixed:**

- **Added `query_prometheus` Tool**: Accepts `project_id`, `query`, `time`, and `timeout` parameters, executing instant PromQL queries against `projects/{project_id}/location/global/prometheus/api/v1/query`.
- **Added Response Parsing**: Automatically handles Google API Gateway `HttpBody` Base64 encoding/decoding, returning standard Prometheus-compatible JSON.
- **Added Testing Seam**: Added an unexported `endpoint` field on `handlers` to support offline `httptest.NewServer` integration testing.
- **Registered via Registry**: Registered the tool using `registry.RegisterTool` to ensure compatibility with MockMode interception in evaluation pipelines.
- **Added Unit Tests**: Added unit tests covering argument validation, Base64 payload decoding, raw JSON handling, API error handling, and MCP tool registration.

## Why This Matters

### 1. Enables Metric-Based Troubleshooting

- Allows AI agents to query GKE metrics via standard PromQL to accurately diagnose cluster disruptions.

### 2. Robust Data Handling & High Testability

- Automatically decodes API Gateway Base64 responses while providing a clean `httptest` seam for unit tests without needing live GCP authentication.

### 3. Zero Regression Risk

- Purely additive change registered via `registry.RegisterTool`; existing monitoring tools remain unaffected.

## Context

- Part of #470
- This is Part 1 of a 2-PR split:
  - **PR 1 (This PR)**: Core `query_prometheus` tool implementation & unit tests.
  - **PR 2 (Follow-up)**: Mock data routing and DevOps Bench evaluation suite updates (`past_interruption_confirmed_by_metrics` & `no_maintenance_events_detected`).

## Testing

```bash
# 1. Unit Tests (Offline httptest mock server)
go test -v ./pkg/tools/monitoring/...  # Pass (11/11 unit tests passed)
go test ./...                         # Pass (All repo tests passed)

# 2. End-to-End Live Integration Test (Real GCP)
# Verified against project 'wujie-gke-dev-test-2' with query 'up':
# Received live GKE metrics for cluster 'devops-bench-test' in 0.50s.