### PR TITLE
feat(evals): add mock support for monitoring_time_series_chart, mql_validator tool and mock data for jobset-interruption skill

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -172,7 +172,7 @@ func startMCPServer(ctx context.Context, opts startOptions) {
 			},
 			InitializedHandler: func(ctx context.Context, req *mcp.InitializedRequest) {
 				params := req.Session.InitializeParams()
-				if supportsMCPApps(params.Capabilities) {
+				if !c.MockMode() && supportsMCPApps(params.Capabilities) {
 					log.Println("Verified: Client host supports MCP Apps. Registering apps...")
 					if err := apps.InstallApps(ctx, s, c); err != nil {
 						log.Printf("Failed to install apps: %v\n", err)
@@ -207,6 +207,13 @@ func startMCPServer(ctx context.Context, opts startOptions) {
 
 	if err := tools.Install(ctx, s, c); err != nil {
 		log.Fatalf("Failed to install tools: %v\n", err)
+	}
+
+	if c.MockMode() {
+		log.Println("MockMode active: Installing apps tools synchronously during server startup...")
+		if err := apps.InstallApps(ctx, s, c); err != nil {
+			log.Fatalf("Failed to install apps tools in MockMode: %v\n", err)
+		}
 	}
 
 	// start server in the right mode

--- a/mock_data/gke-ai-troubleshooting-jobset-interruption/faulty_physical_host_detected.json
+++ b/mock_data/gke-ai-troubleshooting-jobset-interruption/faulty_physical_host_detected.json
@@ -1,0 +1,26 @@
+{
+  "monitoring_time_series_chart": [
+    {
+      "query_contains": "kube_jobset_restarts",
+      "response": "fetch k8s_container | metric 'prometheus.googleapis.com/kube_jobset_restarts/gauge' | filter (jobset == 'training-job')\nTimestamp: 2026-05-20T08:14:00Z Value: 5.0"
+    },
+    {
+      "query_contains": "interruption_count",
+      "response": "fetch k8s_node | metric 'kubernetes.io/node_pool/interruption_count'\nTimestamp: 2026-05-20T08:14:00Z Value: 0.0"
+    },
+    {
+      "query_contains": "gce_topology_host",
+      "response": "fetch k8s_node | metric 'kubernetes.io/node/cpu/total_cores' | group_by [metadata.user.gce_topology_host, node_name]\nHost: physical-host-rack-42 | Nodes: gke-node-a1 (Unready), gke-node-a2 (Unready)\nHost: physical-host-rack-99 | Nodes: gke-node-b1 (Ready)"
+    },
+    {
+      "query_contains": "status",
+      "response": "fetch k8s_node | metric 'kubernetes.io/node/status'\nNode gke-node-a1: Ready=False (NodeNotReady)\nNode gke-node-a2: Ready=False (NodeNotReady)"
+    }
+  ],
+  "query_logs": [
+    {
+      "query_contains": "NodeNotReady",
+      "response": "2026-05-20T08:10:00Z node gke-node-a1 status is NodeNotReady\n2026-05-20T08:10:05Z node gke-node-a2 status is NodeNotReady"
+    }
+  ]
+}

--- a/mock_data/gke-ai-troubleshooting-jobset-interruption/faulty_physical_host_detected.json
+++ b/mock_data/gke-ai-troubleshooting-jobset-interruption/faulty_physical_host_detected.json
@@ -2,25 +2,57 @@
   "monitoring_time_series_chart": [
     {
       "query_contains": "kube_jobset_restarts",
-      "response": "fetch k8s_container | metric 'prometheus.googleapis.com/kube_jobset_restarts/gauge' | filter (jobset == 'training-job')\nTimestamp: 2026-05-20T08:14:00Z Value: 5.0"
+      "response": "fetch k8s_container | metric 'prometheus.googleapis.com/kube_jobset_restarts/gauge' | filter (jobset == 'training-job')\nTimestamp: 2026-05-20T08:14:00Z Value: 2.0 (Restarts occurred)"
+    },
+    {
+      "query_contains": "restart_count",
+      "response": "fetch k8s_container | metric 'kubernetes.io/container/restart_count'\nTimestamp: 2026-05-20T08:14:00Z Value: 2.0 (Restarts occurred)"
     },
     {
       "query_contains": "interruption_count",
-      "response": "fetch k8s_node | metric 'kubernetes.io/node_pool/interruption_count'\nTimestamp: 2026-05-20T08:14:00Z Value: 0.0"
+      "response": "fetch k8s_node | metric 'kubernetes.io/node_pool/interruption_count'\nTimestamp: 2026-05-20T08:14:00Z Value: 0.0 (No nodepool interruptions)"
+    },
+    {
+      "query_contains": "status_condition",
+      "response": "fetch k8s_node | metric 'kubernetes.io/node/status_condition'\nNode gke-node-a1: Ready=False (NodeNotReady)\nNode gke-node-a2: Ready=False (NodeNotReady)"
+    },
+    {
+      "query_contains": "status",
+      "response": "fetch k8s_node | metric 'kubernetes.io/node/status'\nNode gke-node-a1: Ready=False (NodeNotReady)\nNode gke-node-a2: Ready=False (NodeNotReady)"
     },
     {
       "query_contains": "gce_topology_host",
       "response": "fetch k8s_node | metric 'kubernetes.io/node/cpu/total_cores' | group_by [metadata.user.gce_topology_host, node_name]\nHost: physical-host-rack-42 | Nodes: gke-node-a1 (Unready), gke-node-a2 (Unready)\nHost: physical-host-rack-99 | Nodes: gke-node-b1 (Ready)"
     },
     {
-      "query_contains": "status",
-      "response": "fetch k8s_node | metric 'kubernetes.io/node/status'\nNode gke-node-a1: Ready=False (NodeNotReady)\nNode gke-node-a2: Ready=False (NodeNotReady)"
+      "query_contains": "total_cores",
+      "response": "fetch k8s_node | metric 'kubernetes.io/node/cpu/total_cores' | group_by [metadata.user.gce_topology_host, node_name]\nHost: physical-host-rack-42 | Nodes: gke-node-a1 (Unready), gke-node-a2 (Unready)\nHost: physical-host-rack-99 | Nodes: gke-node-b1 (Ready)"
+    },
+    {
+      "query_contains": "unschedulable",
+      "response": "fetch k8s_pod | metric 'kubernetes.io/pod/status/unschedulable'\nTimestamp: 2026-05-20T08:14:00Z Value: 0.0"
+    },
+    {
+      "query_contains": "phase",
+      "response": "fetch k8s_pod | metric 'kubernetes.io/pod/status/phase'\nTimestamp: 2026-05-20T08:14:00Z Phase: Pending Value: 0.0, Phase: Running Value: 0.0"
     }
   ],
   "query_logs": [
     {
       "query_contains": "NodeNotReady",
       "response": "2026-05-20T08:10:00Z node gke-node-a1 status is NodeNotReady\n2026-05-20T08:10:05Z node gke-node-a2 status is NodeNotReady"
+    },
+    {
+      "query_contains": "k8s_node",
+      "response": "2026-05-20T08:10:00Z node gke-node-a1 status is NodeNotReady\n2026-05-20T08:10:05Z node gke-node-a2 status is NodeNotReady"
+    },
+    {
+      "query_contains": "gke-node-a1",
+      "response": "2026-05-20T08:10:00Z node gke-node-a1 status is NodeNotReady (physical host: physical-host-rack-42)"
+    },
+    {
+      "query_contains": "physical-host-rack-42",
+      "response": "2026-05-20T08:10:00Z physical host physical-host-rack-42 reported hardware error affecting nodes gke-node-a1, gke-node-a2"
     }
   ]
 }

--- a/mock_data/gke-ai-troubleshooting-jobset-interruption/no_active_nodes_fallback_or_clean_telemetry.json
+++ b/mock_data/gke-ai-troubleshooting-jobset-interruption/no_active_nodes_fallback_or_clean_telemetry.json
@@ -1,0 +1,49 @@
+{
+  "monitoring_time_series_chart": [
+    {
+      "query_contains": "kube_jobset_restarts",
+      "response": "fetch k8s_container | metric 'prometheus.googleapis.com/kube_jobset_restarts/gauge' | filter (jobset == 'training-job')\nTimestamp: 2026-05-20T08:14:00Z Value: 2.0 (Restarts occurred)"
+    },
+    {
+      "query_contains": "restart_count",
+      "response": "fetch k8s_container | metric 'kubernetes.io/container/restart_count'\nTimestamp: 2026-05-20T08:14:00Z Value: 2.0 (Restarts occurred)"
+    },
+    {
+      "query_contains": "interruption_count",
+      "response": "fetch k8s_node_pool | metric 'kubernetes.io/node_pool/interruption_count'\nTimestamp: 2026-05-20T08:14:00Z Value: 0.0 (No nodepool interruptions)"
+    },
+    {
+      "query_contains": "status_condition",
+      "response": "fetch k8s_node | metric 'kubernetes.io/node/status_condition'\nNo active or assigned nodes discovered for workload 'training-job'."
+    },
+    {
+      "query_contains": "total_cores",
+      "response": "fetch k8s_node | metric 'kubernetes.io/node/cpu/total_cores'\nNo active nodes/nodepools discovered."
+    },
+    {
+      "query_contains": "gce_topology_host",
+      "response": "fetch k8s_node | metric 'kubernetes.io/node/cpu/total_cores'\nNo active nodes/nodepools discovered."
+    },
+    {
+      "query_contains": "unschedulable",
+      "response": "fetch k8s_pod | metric 'kubernetes.io/pod/status/unschedulable'\nTimestamp: 2026-05-20T08:14:00Z Value: 0.0 (Pending/unschedulable pods count is 0)"
+    },
+    {
+      "query_contains": "phase",
+      "response": "fetch k8s_pod | metric 'kubernetes.io/pod/status/phase'\nTimestamp: 2026-05-20T08:14:00Z Phase: Pending Value: 0.0, Phase: Running Value: 0.0 (Pending pods count is 0)"
+    },
+    {
+      "query_contains": "pending",
+      "response": "fetch k8s_pod | metric 'kubernetes.io/pod/status/phase'\nTimestamp: 2026-05-20T08:14:00Z Phase: Pending Value: 0.0 (Pending pods count is 0)"
+    },
+    {
+      "query_contains": "core_usage_time",
+      "response": "fetch k8s_container | metric 'kubernetes.io/container/cpu/core_usage_time'\nTimestamp: 2026-05-20T08:14:00Z Value: 0.0 (No active container CPU usage discovered)"
+    },
+    {
+      "query_contains": "used_bytes",
+      "response": "fetch k8s_container | metric 'kubernetes.io/container/memory/used_bytes'\nTimestamp: 2026-05-20T08:14:00Z Value: 0.0 (No active container memory usage discovered)"
+    }
+  ],
+  "query_logs": []
+}

--- a/mock_data/gke-ai-troubleshooting-jobset-interruption/no_active_nodes_fallback_or_clean_telemetry.json
+++ b/mock_data/gke-ai-troubleshooting-jobset-interruption/no_active_nodes_fallback_or_clean_telemetry.json
@@ -44,6 +44,5 @@
       "query_contains": "used_bytes",
       "response": "fetch k8s_container | metric 'kubernetes.io/container/memory/used_bytes'\nTimestamp: 2026-05-20T08:14:00Z Value: 0.0 (No active container memory usage discovered)"
     }
-  ],
-  "query_logs": []
+  ]
 }

--- a/mock_data/gke-ai-troubleshooting-jobset-interruption/no_jobset_restarts_detected.json
+++ b/mock_data/gke-ai-troubleshooting-jobset-interruption/no_jobset_restarts_detected.json
@@ -1,0 +1,8 @@
+{
+  "monitoring_time_series_chart": [
+    {
+      "query_contains": "kube_jobset_restarts",
+      "response": "fetch k8s_container | metric 'prometheus.googleapis.com/kube_jobset_restarts/gauge' | filter (jobset == 'training-job')\nTimestamp: 2026-05-20T08:14:00Z Value: 0.0 (No restarts detected)"
+    }
+  ]
+}

--- a/mock_data/gke-ai-troubleshooting-jobset-interruption/no_jobset_restarts_detected.json
+++ b/mock_data/gke-ai-troubleshooting-jobset-interruption/no_jobset_restarts_detected.json
@@ -3,6 +3,10 @@
     {
       "query_contains": "kube_jobset_restarts",
       "response": "fetch k8s_container | metric 'prometheus.googleapis.com/kube_jobset_restarts/gauge' | filter (jobset == 'training-job')\nTimestamp: 2026-05-20T08:14:00Z Value: 0.0 (No restarts detected)"
+    },
+    {
+      "query_contains": "restart_count",
+      "response": "fetch k8s_container | metric 'kubernetes.io/container/restart_count'\nTimestamp: 2026-05-20T08:14:00Z Value: 0.0 (No restarts detected)"
     }
   ]
 }

--- a/mock_data/gke-ai-troubleshooting-jobset-interruption/single_node_unready_no_host_correlation.json
+++ b/mock_data/gke-ai-troubleshooting-jobset-interruption/single_node_unready_no_host_correlation.json
@@ -1,0 +1,22 @@
+{
+  "monitoring_time_series_chart": [
+    {
+      "query_contains": "kube_jobset_restarts",
+      "response": "fetch k8s_container | metric 'prometheus.googleapis.com/kube_jobset_restarts/gauge' | filter (jobset == 'training-job')\nTimestamp: 2026-05-20T08:14:00Z Value: 1.0"
+    },
+    {
+      "query_contains": "interruption_count",
+      "response": "fetch k8s_node | metric 'kubernetes.io/node_pool/interruption_count'\nTimestamp: 2026-05-20T08:14:00Z Value: 0.0"
+    },
+    {
+      "query_contains": "gce_topology_host",
+      "response": "fetch k8s_node | metric 'kubernetes.io/node/cpu/total_cores' | group_by [metadata.user.gce_topology_host, node_name]\nHost: physical-host-rack-11 | Nodes: gke-node-x1 (Unready)\nHost: physical-host-rack-22 | Nodes: gke-node-x2 (Ready)\nHost: physical-host-rack-33 | Nodes: gke-node-x3 (Ready)"
+    }
+  ],
+  "query_logs": [
+    {
+      "query_contains": "NodeNotReady",
+      "response": "2026-05-20T08:10:00Z node gke-node-x1 status is NodeNotReady"
+    }
+  ]
+}

--- a/mock_data/gke-ai-troubleshooting-jobset-interruption/single_node_unready_no_host_correlation.json
+++ b/mock_data/gke-ai-troubleshooting-jobset-interruption/single_node_unready_no_host_correlation.json
@@ -2,21 +2,41 @@
   "monitoring_time_series_chart": [
     {
       "query_contains": "kube_jobset_restarts",
-      "response": "fetch k8s_container | metric 'prometheus.googleapis.com/kube_jobset_restarts/gauge' | filter (jobset == 'training-job')\nTimestamp: 2026-05-20T08:14:00Z Value: 1.0"
+      "response": "fetch k8s_container | metric 'prometheus.googleapis.com/kube_jobset_restarts/gauge' | filter (jobset == 'training-job')\nTimestamp: 2026-05-20T08:14:00Z Value: 0.0 (No restarts detected)"
     },
     {
       "query_contains": "interruption_count",
-      "response": "fetch k8s_node | metric 'kubernetes.io/node_pool/interruption_count'\nTimestamp: 2026-05-20T08:14:00Z Value: 0.0"
+      "response": "fetch k8s_node | metric 'kubernetes.io/node_pool/interruption_count'\nTimestamp: 2026-05-20T08:14:00Z Value: 0.0 (No nodepool interruptions detected)"
+    },
+    {
+      "query_contains": "status_condition",
+      "response": "fetch k8s_node | metric 'kubernetes.io/node/status_condition'\nNode gke-node-x1 condition Ready is False (Unready at 2026-05-20T08:10:00Z)"
     },
     {
       "query_contains": "gce_topology_host",
       "response": "fetch k8s_node | metric 'kubernetes.io/node/cpu/total_cores' | group_by [metadata.user.gce_topology_host, node_name]\nHost: physical-host-rack-11 | Nodes: gke-node-x1 (Unready)\nHost: physical-host-rack-22 | Nodes: gke-node-x2 (Ready)\nHost: physical-host-rack-33 | Nodes: gke-node-x3 (Ready)"
+    },
+    {
+      "query_contains": "total_cores",
+      "response": "fetch k8s_node | metric 'kubernetes.io/node/cpu/total_cores'\nHost: physical-host-rack-11 | Nodes: gke-node-x1 (Unready)\nHost: physical-host-rack-22 | Nodes: gke-node-x2 (Ready)\nHost: physical-host-rack-33 | Nodes: gke-node-x3 (Ready)"
     }
   ],
   "query_logs": [
     {
       "query_contains": "NodeNotReady",
       "response": "2026-05-20T08:10:00Z node gke-node-x1 status is NodeNotReady"
+    },
+    {
+      "query_contains": "k8s_node",
+      "response": "2026-05-20T08:10:00Z node gke-node-x1 status is NodeNotReady / NodeStatusUnknown"
+    },
+    {
+      "query_contains": "maintenance",
+      "response": "2026-05-20T08:10:00Z node gke-node-x1 experiencing maintenance event"
+    },
+    {
+      "query_contains": "termination",
+      "response": "2026-05-20T08:10:00Z node gke-node-x1 impending node termination"
     }
   ]
 }

--- a/mock_data/gke-ai-troubleshooting-jobset-interruption/spot_preemption_detected.json
+++ b/mock_data/gke-ai-troubleshooting-jobset-interruption/spot_preemption_detected.json
@@ -2,7 +2,11 @@
   "monitoring_time_series_chart": [
     {
       "query_contains": "kube_jobset_restarts",
-      "response": "fetch k8s_container | metric 'prometheus.googleapis.com/kube_jobset_restarts/gauge' | filter (jobset == 'training-job')\nTimestamp: 2026-05-20T08:14:00Z Value: 3.0"
+      "response": "fetch k8s_container | metric 'prometheus.googleapis.com/kube_jobset_restarts/gauge' | filter (jobset == 'training-job')\nTimestamp: 2026-05-20T08:14:00Z Value: 3.0 (Restarts occurred)"
+    },
+    {
+      "query_contains": "restart_count",
+      "response": "fetch k8s_container | metric 'kubernetes.io/container/restart_count'\nTimestamp: 2026-05-20T08:14:00Z Value: 3.0 (Restarts occurred)"
     },
     {
       "query_contains": "interruption_count",
@@ -13,6 +17,14 @@
     {
       "query_contains": "interruption",
       "response": "2026-05-20T08:12:05Z GCE instance spot-node-1 received preemption notice."
+    },
+    {
+      "query_contains": "preemption",
+      "response": "2026-05-20T08:12:05Z GCE instance spot-node-1 received Spot VM preemption event."
+    },
+    {
+      "query_contains": "gke_nodepool",
+      "response": "2026-05-20T08:12:05Z spot-pool-1 scale-down due to Spot VM preemption."
     }
   ]
 }

--- a/mock_data/gke-ai-troubleshooting-jobset-interruption/spot_preemption_detected.json
+++ b/mock_data/gke-ai-troubleshooting-jobset-interruption/spot_preemption_detected.json
@@ -1,0 +1,18 @@
+{
+  "monitoring_time_series_chart": [
+    {
+      "query_contains": "kube_jobset_restarts",
+      "response": "fetch k8s_container | metric 'prometheus.googleapis.com/kube_jobset_restarts/gauge' | filter (jobset == 'training-job')\nTimestamp: 2026-05-20T08:14:00Z Value: 3.0"
+    },
+    {
+      "query_contains": "interruption_count",
+      "response": "fetch k8s_node | metric 'kubernetes.io/node_pool/interruption_count' | filter (node_pool == 'spot-pool-1')\nTimestamp: 2026-05-20T08:12:00Z Value: 4.0 (Preemption/Maintenance event detected on Spot VM pool)"
+    }
+  ],
+  "query_logs": [
+    {
+      "query_contains": "interruption",
+      "response": "2026-05-20T08:12:05Z GCE instance spot-node-1 received preemption notice."
+    }
+  ]
+}

--- a/mock_data/gke-ai-troubleshooting-jobset-interruption/unschedulable_pods_resource_exhaustion.json
+++ b/mock_data/gke-ai-troubleshooting-jobset-interruption/unschedulable_pods_resource_exhaustion.json
@@ -2,20 +2,52 @@
   "monitoring_time_series_chart": [
     {
       "query_contains": "kube_jobset_restarts",
-      "response": "fetch k8s_container | metric 'prometheus.googleapis.com/kube_jobset_restarts/gauge' | filter (jobset == 'training-job')\nTimestamp: 2026-05-20T08:14:00Z Value: 2.0"
+      "response": "fetch k8s_container | metric 'prometheus.googleapis.com/kube_jobset_restarts/gauge' | filter (jobset == 'training-job')\nTimestamp: 2026-05-20T08:14:00Z Value: 2.0 (Restarts occurred)"
+    },
+    {
+      "query_contains": "restart_count",
+      "response": "fetch k8s_container | metric 'kubernetes.io/container/restart_count'\nTimestamp: 2026-05-20T08:14:00Z Value: 2.0 (Restarts occurred)"
     },
     {
       "query_contains": "interruption_count",
-      "response": "fetch k8s_node | metric 'kubernetes.io/node_pool/interruption_count'\nTimestamp: 2026-05-20T08:14:00Z Value: 0.0"
+      "response": "fetch k8s_node | metric 'kubernetes.io/node_pool/interruption_count'\nTimestamp: 2026-05-20T08:14:00Z Value: 0.0 (No nodepool interruptions)"
+    },
+    {
+      "query_contains": "status_condition",
+      "response": "fetch k8s_node | metric 'kubernetes.io/node/status_condition'\nAll nodes Ready=True (Healthy nodes, no node failure)"
+    },
+    {
+      "query_contains": "total_cores",
+      "response": "fetch k8s_node | metric 'kubernetes.io/node/cpu/total_cores'\nAll nodes Ready=True (Healthy nodes, no node failure)"
+    },
+    {
+      "query_contains": "gce_topology_host",
+      "response": "fetch k8s_node | metric 'kubernetes.io/node/cpu/total_cores'\nAll nodes Ready=True (Healthy nodes, no node failure)"
     },
     {
       "query_contains": "unschedulable",
       "response": "fetch k8s_pod | metric 'kubernetes.io/pod/status/unschedulable' | filter (resource.label.namespace == 'default')\nTimestamp: 2026-05-20T08:14:00Z Value: 8.0 (8 pods pending/unschedulable due to Insufficient cpu/memory)"
+    },
+    {
+      "query_contains": "phase",
+      "response": "fetch k8s_pod | metric 'kubernetes.io/pod/status/phase'\nTimestamp: 2026-05-20T08:14:00Z Phase: Pending Value: 8.0 (8 pods pending/unschedulable due to Insufficient cpu/memory)"
+    },
+    {
+      "query_contains": "pending",
+      "response": "fetch k8s_pod | metric 'kubernetes.io/pod/status/phase'\nTimestamp: 2026-05-20T08:14:00Z Phase: Pending Value: 8.0 (8 pods pending/unschedulable due to Insufficient cpu/memory)"
     }
   ],
   "query_logs": [
     {
       "query_contains": "FailedScheduling",
+      "response": "2026-05-20T08:12:00Z 0/10 nodes are available: 10 Insufficient cpu."
+    },
+    {
+      "query_contains": "k8s_pod",
+      "response": "2026-05-20T08:12:00Z 0/10 nodes are available: 10 Insufficient cpu."
+    },
+    {
+      "query_contains": "unschedulable",
       "response": "2026-05-20T08:12:00Z 0/10 nodes are available: 10 Insufficient cpu."
     }
   ]

--- a/mock_data/gke-ai-troubleshooting-jobset-interruption/unschedulable_pods_resource_exhaustion.json
+++ b/mock_data/gke-ai-troubleshooting-jobset-interruption/unschedulable_pods_resource_exhaustion.json
@@ -1,0 +1,22 @@
+{
+  "monitoring_time_series_chart": [
+    {
+      "query_contains": "kube_jobset_restarts",
+      "response": "fetch k8s_container | metric 'prometheus.googleapis.com/kube_jobset_restarts/gauge' | filter (jobset == 'training-job')\nTimestamp: 2026-05-20T08:14:00Z Value: 2.0"
+    },
+    {
+      "query_contains": "interruption_count",
+      "response": "fetch k8s_node | metric 'kubernetes.io/node_pool/interruption_count'\nTimestamp: 2026-05-20T08:14:00Z Value: 0.0"
+    },
+    {
+      "query_contains": "unschedulable",
+      "response": "fetch k8s_pod | metric 'kubernetes.io/pod/status/unschedulable' | filter (resource.label.namespace == 'default')\nTimestamp: 2026-05-20T08:14:00Z Value: 8.0 (8 pods pending/unschedulable due to Insufficient cpu/memory)"
+    }
+  ],
+  "query_logs": [
+    {
+      "query_contains": "FailedScheduling",
+      "response": "2026-05-20T08:12:00Z 0/10 nodes are available: 10 Insufficient cpu."
+    }
+  ]
+}

--- a/pkg/apps/charts/charts.go
+++ b/pkg/apps/charts/charts.go
@@ -24,6 +24,7 @@ import (
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	monitoringpb "cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
+	"github.com/GoogleCloudPlatform/gke-mcp/pkg/tools/registry"
 	"github.com/GoogleCloudPlatform/gke-mcp/ui"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"google.golang.org/api/iterator"
@@ -84,7 +85,7 @@ func Install(_ context.Context, s *mcp.Server, c *config.Config) error {
 		c: c,
 	}
 
-	mcp.AddTool(s, &mcp.Tool{
+	registry.RegisterTool(s, c, &mcp.Tool{
 		Name:        "monitoring_time_series_chart",
 		Description: "Interactive tool to display time series data using a React Chart. ALWAYS favor using this tool to query metrics rather than outputting raw values so the user gets a visualization. MUST Call `mql_validator` FIRST to catch syntax issues or metric anomalies before running this tool.",
 		Annotations: &mcp.ToolAnnotations{
@@ -150,7 +151,7 @@ func Install(_ context.Context, s *mcp.Server, c *config.Config) error {
 		},
 	}, h.queryTimeSeries)
 
-	mcp.AddTool(s, &mcp.Tool{
+	registry.RegisterTool(s, c, &mcp.Tool{
 		Name:        "mql_validator",
 		Description: "A helper tool to validate Monitoring Query Language (MQL) metric strings. MUST be called immediately before calling `monitoring_time_series_chart` or `query_time_series` to ensure the MQL statement compiles correctly. It fetches 1 page of data to verify syntactical and logical correctness. Returns the original string on success, or an error payload explaining the misconfiguration.",
 		Annotations: &mcp.ToolAnnotations{

--- a/pkg/tools/registry/registry.go
+++ b/pkg/tools/registry/registry.go
@@ -33,13 +33,14 @@ var (
 	safeNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 )
 
-type queryLogMockRule struct {
+type queryMockRule struct {
 	QueryContains string `json:"query_contains,omitempty"`
 	Response      string `json:"response,omitempty"`
 }
 
 type caseMockData struct {
-	QueryLogs []queryLogMockRule `json:"query_logs,omitempty"`
+	QueryLogs                  []queryMockRule `json:"query_logs,omitempty"`
+	MonitoringTimeSeriesCharts []queryMockRule `json:"monitoring_time_series_chart,omitempty"`
 }
 
 // RegisterTool wraps mcp.AddTool to intercept and mock tool execution in MockMode.
@@ -120,19 +121,52 @@ func handleMockToolCall(_ context.Context, toolName string, args any, c *config.
 		}, nil, nil
 	}
 
-	if toolName == "query_logs" {
-		argsMap, err := extractArgsMap(args)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to parse arguments: %w", err)
-		}
-		query, _ := argsMap["query"].(string)
-		res, err := resolveQueryLogsMock(mockBytes, query)
-		return res, nil, err
+	var data caseMockData
+	if err := json.Unmarshal(mockBytes, &data); err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal mock data: %w", err)
 	}
 
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("no mock implementation available for tool %s", toolName)}},
-	}, nil, nil
+	switch toolName {
+	case "query_logs":
+		query, err := extractQueryArg(args)
+		if err != nil {
+			return nil, nil, err
+		}
+		return matchQueryRules(data.QueryLogs, query), nil, nil
+
+	case "monitoring_time_series_chart":
+		query, err := extractQueryArg(args)
+		if err != nil {
+			return nil, nil, err
+		}
+		return matchQueryRules(data.MonitoringTimeSeriesCharts, query), nil, nil
+
+	case "mql_validator":
+		query, err := extractQueryArg(args)
+		if err != nil {
+			return nil, nil, err
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: query},
+			},
+		}, nil, nil
+
+	default:
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("no mock implementation available for tool %s", toolName)}},
+		}, nil, nil
+	}
+}
+
+// extractQueryArg extracts the "query" string parameter from generic tool arguments.
+func extractQueryArg(args any) (string, error) {
+	argsMap, err := extractArgsMap(args)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse arguments: %w", err)
+	}
+	query, _ := argsMap["query"].(string)
+	return query, nil
 }
 
 // extractArgsMap deserializes generic tool arguments into a standard map[string]any.
@@ -146,22 +180,15 @@ func extractArgsMap(args any) (map[string]any, error) {
 	return res, err
 }
 
-// resolveQueryLogsMock handles simulated output for the query_logs tool.
-//
-// It parses the case-wide JSON data and evaluates query log rules sequentially against the LQL query string.
-func resolveQueryLogsMock(mockDataBytes []byte, query string) (*mcp.CallToolResult, error) {
-	var data caseMockData
-	if err := json.Unmarshal(mockDataBytes, &data); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal mock data: %w", err)
-	}
-
-	for _, rule := range data.QueryLogs {
+// matchQueryRules evaluates mock rules sequentially against the query string.
+func matchQueryRules(rules []queryMockRule, query string) *mcp.CallToolResult {
+	for _, rule := range rules {
 		if rule.QueryContains != "" && strings.Contains(query, rule.QueryContains) {
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{
 					&mcp.TextContent{Text: rule.Response},
 				},
-			}, nil
+			}
 		}
 	}
 
@@ -169,5 +196,5 @@ func resolveQueryLogsMock(mockDataBytes []byte, query string) (*mcp.CallToolResu
 		Content: []mcp.Content{
 			&mcp.TextContent{Text: fmt.Sprintf("no mock rule matched for query: %s", query)},
 		},
-	}, nil
+	}
 }

--- a/pkg/tools/registry/registry_test.go
+++ b/pkg/tools/registry/registry_test.go
@@ -21,9 +21,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-
 	"github.com/GoogleCloudPlatform/gke-mcp/pkg/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func TestExtractArgsMap(t *testing.T) {
@@ -50,26 +49,38 @@ func TestExtractArgsMap(t *testing.T) {
 	}
 }
 
-func TestResolveQueryLogsMock(t *testing.T) {
-	mockJSON := `{
-		"query_logs": [
-			{
-				"query_contains": "vbar_control_agent",
-				"response": "I0702 OOM detected in vbar_control_agent"
-			},
-			{
-				"query_contains": "device_plugin",
-				"response": "Device plugin healthy"
-			}
-		]
-	}`
+func TestExtractQueryArg(t *testing.T) {
+	type dummyArgs struct {
+		Query string `json:"query"`
+	}
+
+	args := dummyArgs{
+		Query: "resource.type=k8s_cluster",
+	}
+
+	query, err := extractQueryArg(args)
+	if err != nil {
+		t.Fatalf("extractQueryArg failed: %v", err)
+	}
+	if query != "resource.type=k8s_cluster" {
+		t.Errorf("extractQueryArg() = %q, want %q", query, "resource.type=k8s_cluster")
+	}
+}
+
+func TestMatchQueryRules(t *testing.T) {
+	rules := []queryMockRule{
+		{
+			QueryContains: "vbar_control_agent",
+			Response:      "I0702 OOM detected in vbar_control_agent",
+		},
+		{
+			QueryContains: "device_plugin",
+			Response:      "Device plugin healthy",
+		},
+	}
 
 	t.Run("matching query rule", func(t *testing.T) {
-		res, err := resolveQueryLogsMock([]byte(mockJSON), `resource.labels.cluster_name="c" AND "vbar_control_agent"`)
-		if err != nil {
-			t.Fatalf("resolveQueryLogsMock failed: %v", err)
-		}
-
+		res := matchQueryRules(rules, `resource.labels.cluster_name="c" AND "vbar_control_agent"`)
 		if len(res.Content) == 0 {
 			t.Fatal("expected content in CallToolResult")
 		}
@@ -85,11 +96,7 @@ func TestResolveQueryLogsMock(t *testing.T) {
 	})
 
 	t.Run("unmatched query rule", func(t *testing.T) {
-		res, err := resolveQueryLogsMock([]byte(mockJSON), `resource.type="k8s_node" AND "unknown_log"`)
-		if err != nil {
-			t.Fatalf("resolveQueryLogsMock failed: %v", err)
-		}
-
+		res := matchQueryRules(rules, `resource.type="k8s_node" AND "unknown_log"`)
 		textContent, ok := res.Content[0].(*mcp.TextContent)
 		if !ok {
 			t.Fatalf("expected *mcp.TextContent, got %T", res.Content[0])
@@ -97,13 +104,6 @@ func TestResolveQueryLogsMock(t *testing.T) {
 
 		if !strings.Contains(textContent.Text, "no mock rule matched for query") {
 			t.Errorf("textContent.Text = %q, want unmatched error string", textContent.Text)
-		}
-	})
-
-	t.Run("invalid json", func(t *testing.T) {
-		_, err := resolveQueryLogsMock([]byte(`invalid json`), `query`)
-		if err == nil {
-			t.Error("expected error for invalid json, got nil")
 		}
 	})
 }
@@ -116,7 +116,7 @@ func TestHandleMockToolCall_EndToEnd(t *testing.T) {
 		t.Fatalf("failed to create skill dir: %v", err)
 	}
 
-	caseMockContent := `{
+	caseMock := `{
 		"query_logs": [
 			{
 				"query_contains": "error_log",
@@ -125,7 +125,7 @@ func TestHandleMockToolCall_EndToEnd(t *testing.T) {
 		]
 	}`
 	mockFilePath := filepath.Join(skillDir, "my_test_case.json")
-	if err := os.WriteFile(mockFilePath, []byte(caseMockContent), 0600); err != nil {
+	if err := os.WriteFile(mockFilePath, []byte(caseMock), 0600); err != nil {
 		t.Fatalf("failed to write mock file: %v", err)
 	}
 
@@ -208,7 +208,7 @@ func TestHandleMockToolCall_EndToEnd(t *testing.T) {
 
 		textContent := res.Content[0].(*mcp.TextContent)
 		if !strings.Contains(textContent.Text, "no mock implementation available") {
-			t.Errorf("Text = %q, want unsupported tool message", textContent.Text)
+			t.Errorf("Text = %q, want unsupported tool error message", textContent.Text)
 		}
 	})
 
@@ -226,6 +226,59 @@ func TestHandleMockToolCall_EndToEnd(t *testing.T) {
 		textContent := res.Content[0].(*mcp.TextContent)
 		if textContent.Text != "Found synthetic error log" {
 			t.Errorf("Text = %q, want %q", textContent.Text, "Found synthetic error log")
+		}
+	})
+
+	t.Run("monitoring_time_series_chart mock tool call", func(t *testing.T) {
+		t.Setenv("GKE_MCP_MOCK_SKILL", "my-skill")
+		chartMock := `{
+			"monitoring_time_series_chart": [
+				{
+					"query_contains": "kube_jobset_restarts",
+					"response": "JobSet restarts detected: 2.0"
+				}
+			]
+		}`
+		if err := os.WriteFile(filepath.Join(skillDir, "chart_case.json"), []byte(chartMock), 0600); err != nil {
+			t.Fatalf("failed to write chart mock file: %v", err)
+		}
+		t.Setenv("GKE_MCP_MOCK_CASE", "chart_case")
+
+		args := map[string]any{
+			"query": "fetch k8s_container | metric 'prometheus.googleapis.com/kube_jobset_restarts/gauge'",
+		}
+		res, _, err := handleMockToolCall(ctx, "monitoring_time_series_chart", args, cfg)
+		if err != nil {
+			t.Fatalf("handleMockToolCall failed for monitoring_time_series_chart: %v", err)
+		}
+
+		textContent := res.Content[0].(*mcp.TextContent)
+		if textContent.Text != "JobSet restarts detected: 2.0" {
+			t.Errorf("Text = %q, want %q", textContent.Text, "JobSet restarts detected: 2.0")
+		}
+	})
+
+	t.Run("mql_validator mock tool call", func(t *testing.T) {
+		t.Setenv("GKE_MCP_MOCK_SKILL", "my-skill")
+		t.Setenv("GKE_MCP_MOCK_CASE", "my_test_case")
+
+		args := map[string]any{
+			"query": "fetch k8s_pod",
+		}
+		res, _, err := handleMockToolCall(ctx, "mql_validator", args, cfg)
+		if err != nil {
+			t.Fatalf("handleMockToolCall failed for mql_validator: %v", err)
+		}
+
+		if len(res.Content) == 0 {
+			t.Fatalf("expected non-empty Content")
+		}
+		textContent, ok := res.Content[0].(*mcp.TextContent)
+		if !ok {
+			t.Fatalf("expected *mcp.TextContent, got %T", res.Content[0])
+		}
+		if textContent.Text != "fetch k8s_pod" {
+			t.Errorf("Text = %q, want %q", textContent.Text, "fetch k8s_pod")
 		}
 	})
 }
@@ -411,6 +464,68 @@ func TestRegisterTool_MockModeToggle(t *testing.T) {
 		textContent := res.Content[0].(*mcp.TextContent)
 		if textContent.Text != "prod response" {
 			t.Errorf("got text %q, want %q", textContent.Text, "prod response")
+		}
+	})
+
+	t.Run("mql_validator intercepts tool call in mock mode", func(t *testing.T) {
+		mqlTool := &mcp.Tool{
+			Name:        "mql_validator",
+			Description: "validate MQL query",
+		}
+		prodHandlerCalled := false
+		prodHandler := func(_ context.Context, _ *mcp.CallToolRequest, _ dummyArgs) (*mcp.CallToolResult, any, error) {
+			prodHandlerCalled = true
+			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "prod validator"}}}, nil, nil
+		}
+
+		t.Setenv("GKE_MCP_MOCK", "true")
+		t.Setenv("GKE_MCP_MOCK_DATA_DIR", tempDir)
+		t.Setenv("GKE_MCP_MOCK_SKILL", "my-skill")
+		t.Setenv("GKE_MCP_MOCK_CASE", "my_case")
+		cfg := config.New("test", false)
+
+		server := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
+		RegisterTool(server, cfg, mqlTool, prodHandler)
+
+		clientTransport, serverTransport := mcp.NewInMemoryTransports()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		go func() {
+			_ = server.Run(ctx, serverTransport)
+		}()
+
+		client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "1.0.0"}, nil)
+		session, err := client.Connect(ctx, clientTransport, nil)
+		if err != nil {
+			t.Fatalf("failed to connect client: %v", err)
+		}
+		defer func() { _ = session.Close() }()
+
+		res, err := session.CallTool(ctx, &mcp.CallToolParams{
+			Name: "mql_validator",
+			Arguments: map[string]any{
+				"cluster_name": "c",
+				"query":        "fetch k8s_pod",
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool failed: %v", err)
+		}
+
+		if prodHandlerCalled {
+			t.Errorf("expected prodHandlerCalled to be false in mock mode for mql_validator")
+		}
+
+		if len(res.Content) == 0 {
+			t.Fatalf("expected non-empty Content")
+		}
+		textContent, ok := res.Content[0].(*mcp.TextContent)
+		if !ok {
+			t.Fatalf("expected *mcp.TextContent, got %T", res.Content[0])
+		}
+		if textContent.Text != "fetch k8s_pod" {
+			t.Errorf("Text = %q, want %q", textContent.Text, "fetch k8s_pod")
 		}
 	})
 }


### PR DESCRIPTION
# Pull Request

## Why This Change

Offline evaluation of GKE AI troubleshooting skills (specifically `gke-ai-troubleshooting-jobset-interruption`) requires deterministic telemetry mocks for Cloud Monitoring tools (`monitoring_time_series_chart` and `mql_validator`). Previously:

1. `monitoring_time_series_chart` and `mql_validator` lacked mock interception in `MockMode`, leading to `PermissionDenied` errors from Cloud Monitoring API calls during benchmark runs.
2. App-related tools registered asynchronously post-handshake, causing headless evaluation clients to miss app tools in `tools/list`.
3. Test cases under `gke-ai-troubleshooting-jobset-interruption` lacked synthetic metric datasets for JobSet restarts, nodepool interruptions, unschedulable pod counts, and physical host correlation.

This PR adds full `MockMode` support for `monitoring_time_series_chart` and `mql_validator`, ensures synchronous startup tool registration, and introduces comprehensive mock telemetry datasets across 6 JobSet interruption evaluation scenarios.

## What Changed

**Files:**

- `cmd/root.go`
- `pkg/apps/charts/charts.go`
- `pkg/tools/registry/registry.go`
- `pkg/tools/registry/registry_test.go`

**Mock Data JSON Files:**
- `mock_data/gke-ai-troubleshooting-jobset-interruption/faulty_physical_host_detected.json`
- `mock_data/gke-ai-troubleshooting-jobset-interruption/no_active_nodes_fallback_or_clean_telemetry.json`
- `mock_data/gke-ai-troubleshooting-jobset-interruption/no_jobset_restarts_detected.json`
- `mock_data/gke-ai-troubleshooting-jobset-interruption/single_node_unready_no_host_correlation.json`
- `mock_data/gke-ai-troubleshooting-jobset-interruption/spot_preemption_detected.json`
- `mock_data/gke-ai-troubleshooting-jobset-interruption/unschedulable_pods_resource_exhaustion.json`

**Added/Changed/Fixed:**

- **Added**: Mock routing middleware interception for `monitoring_time_series_chart` and `mql_validator` in `pkg/tools/registry/registry.go`.
- **Added**: Synthetic mock telemetry JSON datasets across 6 test case scenarios under `mock_data/gke-ai-troubleshooting-jobset-interruption/`.
- **Added**: Comprehensive unit test cases in `pkg/tools/registry/registry_test.go` for `monitoring_time_series_chart` rule matching and `mql_validator` interception.
- **Fixed**: Synchronous startup registration of app tools (`apps.InstallApps`) in `cmd/root.go` during `MockMode`, ensuring app tools appear in `tools/list` immediately upon initialization.

## Why This Matters

### 1. Enables Hermetic Offline Skill Benchmarking

- Allows benchmark evaluations to run offline without live GCP credentials or Cloud Monitoring API access.

### 2. Guarantees Complete Tool Discovery

- Resolves an initialization race condition so evaluation agents always receive `monitoring_time_series_chart` and `mql_validator` alongside standard GKE tools at handshake.

## Context

- Supports evaluation harness infrastructure for GKE AI troubleshooting skills.
- Unblocks evaluation runs for `gke-ai-troubleshooting-jobset-interruption`.

## Testing

```bash
gofmt -w . && go mod tidy && go vet ./...
go test -v ./pkg/tools/registry/...      # Pass
go test -v ./pkg/apps/charts/...         # Pass
./dev/ci/presubmits/validate-skills.sh   # Pass