### PR TITLE
deps(deps): bump @hono/node-server from 1.19.13 to 2.0.12

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1212,13 +1212,13 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"


### PR DESCRIPTION
# Pull Request

## Why This Change

Dependabot alert [#46](https://github.com/GoogleCloudPlatform/gke-mcp/security/dependabot/46) flags `@hono/node-server` < 2.0.5 for [GHSA-frvp-7c67-39w9](https://github.com/honojs/node-server/security/advisories/GHSA-frvp-7c67-39w9) (CWE-22 path traversal, CVSS 5.9 medium).

On Windows hosts, an encoded backslash (`%5C`) in a request path decodes to `\`, which the Windows path resolver treats as a separator. `serve-static` resolves a single URL segment such as `admin\secret.txt` into a nested file under the root and serves it, bypassing prefix-mounted middleware guarding that subtree. Directory escape via `..` remains blocked, so reads stay within the configured root.

## What Changed

**Files:**

- `ui/package-lock.json`

**Added/Changed/Fixed:**

- Bumped `@hono/node-server` from `1.19.13` to `2.0.12` (advisory range is `< 2.0.5`).

`@hono/node-server` is a transitive **development** dependency, reached only through `@modelcontextprotocol/sdk`. That package already declares `"@hono/node-server": "^1.19.9 || ^2.0.5"`, so the patched major was already in range and `npm update @hono/node-server` resolved it. No `package.json` edit and no `overrides` entry were required.

The root `/package-lock.json` does not contain `@hono/node-server` and is unchanged.

## Why This Matters

### 1

- Clears the only outstanding Dependabot alert for this package and keeps the UI dependency tree free of known advisories.

### 2

- Minimal blast radius: a single lockfile entry, dev-scope only. Nothing in `ui/dist/apps/*/index.html` changed, confirmed by `verify-ui.sh` reporting no diff.

### 3

- The bump crosses a major version (1.x to 2.x), but only the transitive resolution moves. The consuming package already supports `^2.0.5`, and the new minimum Node engine (`>=20`) is satisfied by this repo's toolchain.

## Context

- Advisory: https://github.com/honojs/node-server/security/advisories/GHSA-frvp-7c67-39w9
- Upstream fix: https://github.com/honojs/node-server/commit/cd076e117cfe4cb8d31f9eb11d2e8f38a6cb8faf
- Release: https://github.com/honojs/node-server/releases/tag/v2.0.5
- Two unrelated `npm audit` findings remain in `ui/` and are intentionally out of scope here: `body-parser` (low, GHSA-v422-hmwv-36x6) and `brace-expansion` (high, GHSA-mh99-v99m-4gvg).

## Testing

```bash
./dev/tasks/presubmit.sh        # Could not complete, see note below
./dev/tasks/update-ui.sh        # Pass
./dev/tasks/format.sh           # Pass
./dev/ci/presubmits/ui-test.sh  # Pass, 4 tests
./dev/ci/presubmits/verify-ui.sh        # Pass, no bundle diff
./dev/ci/presubmits/validate-skills.sh  # Pass
./dev/ci/presubmits/verify-workflows.py # Pass
npm --prefix ui run lint        # Pass
```

The full `presubmit.sh` could not run to completion in this environment: the local Go toolchain is 1.19.8, while `go.mod` requires `go 1.26.2`, so the first step (`gomod.sh`) aborts with `invalid go version '1.26.2'` before reaching any Go build, test, or vet step. This is an environment limitation unrelated to the change, and it reproduces on `main`. The Go-dependent checks (`go-build.sh`, `go-test.sh`, `go-vet.sh`, `docker-build.sh`, `golangci-lint.sh`) are therefore unverified locally and are left to CI. This change touches no Go source.

Every non-Go presubmit step was run individually and passed.

---

Dev-dependency-only lockfile bump with no runtime or shipped-artifact impact. Risk is limited to the UI build and test tooling, which is exercised by the checks above.
